### PR TITLE
Feature/audio video recording

### DIFF
--- a/CastorCore/Encoder/Mp4Encoder.cs
+++ b/CastorCore/Encoder/Mp4Encoder.cs
@@ -1,0 +1,39 @@
+﻿using FFMpegCore;
+using FFMpegCore.Pipes;
+
+namespace CastorCore.Encoder
+{
+    public class Mp4Encoder
+    {
+        private readonly IPipeSource _videoPipe;
+        //private readonly IPipeSource _audioPipe;
+        private readonly string _outputPath;
+        private readonly double _frameRate;
+
+        public Mp4Encoder(IPipeSource videoPipe, string outputPath, double frameRate = 60.0)
+        {
+            _videoPipe = videoPipe ?? throw new ArgumentNullException(nameof(videoPipe));
+            _outputPath = outputPath ?? throw new ArgumentNullException(nameof(outputPath));
+            _frameRate = frameRate;
+        }
+
+        public async Task StartAsync(CancellationToken cts = default)
+        {
+            Console.WriteLine($"[Encoder] Starting FFmpeg with framerate: {_frameRate}");
+
+            await FFMpegArguments
+                .FromPipeInput(_videoPipe)
+                .OutputToFile(_outputPath, overwrite: true, options => options
+                    .WithVideoCodec("libx264")
+                    .WithAudioCodec("aac")
+                    .WithFramerate(_frameRate)
+                    .ForceFormat("mp4")
+                    .WithFastStart()
+                )
+                .ProcessAsynchronously();
+
+            Console.WriteLine($"[Encoder] FFmpeg completed successfully");
+        }
+    }
+}
+

--- a/CastorCore/Encoder/Mp4Encoder.cs
+++ b/CastorCore/Encoder/Mp4Encoder.cs
@@ -6,13 +6,16 @@ namespace CastorCore.Encoder
     public class Mp4Encoder
     {
         private readonly IPipeSource _videoPipe;
-        //private readonly IPipeSource _audioPipe;
+        private readonly IPipeSource _audioPipe;
+
         private readonly string _outputPath;
         private readonly double _frameRate;
 
-        public Mp4Encoder(IPipeSource videoPipe, string outputPath, double frameRate = 60.0)
+        public Mp4Encoder(IPipeSource videoPipe, IPipeSource audioPipe, string outputPath, double frameRate = 60.0)
         {
             _videoPipe = videoPipe ?? throw new ArgumentNullException(nameof(videoPipe));
+            _audioPipe = audioPipe ?? throw new ArgumentNullException(nameof(videoPipe));
+
             _outputPath = outputPath ?? throw new ArgumentNullException(nameof(outputPath));
             _frameRate = frameRate;
         }
@@ -22,7 +25,8 @@ namespace CastorCore.Encoder
             Console.WriteLine($"[Encoder] Starting FFmpeg with framerate: {_frameRate}");
 
             await FFMpegArguments
-                .FromPipeInput(_videoPipe)
+                .FromPipeInput(_audioPipe)
+                .AddPipeInput(_videoPipe)
                 .OutputToFile(_outputPath, overwrite: true, options => options
                     .WithVideoCodec("libx264")
                     .WithAudioCodec("aac")

--- a/CastorCore/Frame/AudioSample.cs
+++ b/CastorCore/Frame/AudioSample.cs
@@ -13,14 +13,18 @@ namespace CastorCore.Frame
         public int Channels { get; }
         public int SampleRate { get; }
         public int SampleCount => Data.Length / (Channels * 2); // Assuming 16-bit
-        public TimeSpan Timestamp { get; }
+        public MediaTimestamp Timestamp { get; }
+
+        public int Width => 0;
+        public int Height => 0;
+        public string Format => "s16le";
 
         public AudioSample(byte[] data, int channels, int sampleRate)
-            : this(data, channels, sampleRate, TimeSpan.Zero)
+            : this(data, channels, sampleRate, MediaTimestamp.Zero)
         {
         }
 
-        public AudioSample(byte[] data, int channels, int sampleRate, TimeSpan timestamp)
+        public AudioSample(byte[] data, int channels, int sampleRate, MediaTimestamp timestamp)
         {
             Data = data;
             Channels = channels;
@@ -37,9 +41,5 @@ namespace CastorCore.Frame
         {
             await stream.WriteAsync(Data, token);
         }
-
-        public int Width => 0;
-        public int Height => 0;
-        public string Format => "audio";
     }
 }

--- a/CastorCore/Frame/MediaTimestamp.cs
+++ b/CastorCore/Frame/MediaTimestamp.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CastorCore.Frame
+{
+    public readonly struct MediaTimestamp : IComparable<MediaTimestamp>, IEquatable<MediaTimestamp>
+    {
+        const double MICROSECOND_PER_MILLISECOND = 1000.0;
+        const double SECOND_PER_MILLISECOND = 1000000.0;
+
+        static public MediaTimestamp Zero
+        {
+            get => new MediaTimestamp(0);
+        }
+        
+        public long Microseconds { get; }
+
+        public MediaTimestamp(long microseconds)
+        {
+            Microseconds = microseconds;
+        }
+
+        public static MediaTimestamp FromTimeSpan(TimeSpan ts)
+            => new MediaTimestamp((long)(ts.TotalMilliseconds * MICROSECOND_PER_MILLISECOND));
+
+        public TimeSpan ToTimeSpan()
+            => TimeSpan.FromMilliseconds(Microseconds / MICROSECOND_PER_MILLISECOND);
+
+        public double TotalMilliseconds => Microseconds / MICROSECOND_PER_MILLISECOND;
+        public double TotalSeconds => Microseconds / SECOND_PER_MILLISECOND;
+
+        public static MediaTimestamp Now()
+        {
+            double tickUs = SECOND_PER_MILLISECOND / Stopwatch.Frequency;
+            long us = (long)(Stopwatch.GetTimestamp() * tickUs);
+            return new MediaTimestamp(us);
+        }
+
+        public static MediaTimestamp operator +(MediaTimestamp a, MediaTimestamp b)
+            => new(a.Microseconds + b.Microseconds);
+
+        public static MediaTimestamp operator -(MediaTimestamp a, MediaTimestamp b)
+            => new(a.Microseconds - b.Microseconds);
+
+        public int CompareTo(MediaTimestamp other) => Microseconds.CompareTo(other.Microseconds);
+
+        public bool Equals(MediaTimestamp other) => Microseconds == other.Microseconds;
+        public override bool Equals(object obj) => obj is MediaTimestamp mt && Equals(mt);
+        public override int GetHashCode() => Microseconds.GetHashCode();
+
+        public override string ToString() => Microseconds.ToString();
+    }
+
+}

--- a/CastorCore/Frame/RawVideoFrame.cs
+++ b/CastorCore/Frame/RawVideoFrame.cs
@@ -6,13 +6,15 @@ namespace CastorCore.Frame
     {
         private bool _disposed = false;
 
+        public MediaTimestamp Timestamp { get; }
         public int Width { get; }
         public int Height { get; }
         public string Format => "bgra32";
         public byte[] Data { get; private set; }
 
-        public RawVideoFrame(int width, int height, byte[] data)
+        public RawVideoFrame(MediaTimestamp ts, int width, int height, byte[] data)
         {
+            Timestamp = ts;
             Width = width;
             Height = height;
             Data = data;
@@ -42,7 +44,7 @@ namespace CastorCore.Frame
 
         public void Dispose()
         {
-            if (_disposed)
+            if (!_disposed)
                 return;
 
             _disposed = true;

--- a/CastorCore/Input/Audio/Device/AudioDeviceInfo.cs
+++ b/CastorCore/Input/Audio/Device/AudioDeviceInfo.cs
@@ -1,4 +1,4 @@
-﻿namespace CastorCore.Input.Audio
+﻿namespace CastorCore.Input.Audio.Device
 {
     public class AudioDeviceInfo
     {

--- a/CastorCore/Input/Audio/Device/AudioDeviceManager.cs
+++ b/CastorCore/Input/Audio/Device/AudioDeviceManager.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace CastorCore.Input.Audio
+namespace CastorCore.Input.Audio.Device
 {
     public class AudioDeviceManager
     {
@@ -24,6 +24,16 @@ namespace CastorCore.Input.Audio
             MMDeviceCollection devices = _enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
 
             return devices.ToList();
+        }
+
+        public MMDevice GetDefaultOutputDevice()
+        {
+            return _enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Console);
+        }
+
+        public MMDevice GetDefaultInputDevice()
+        {
+            return _enumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Console);
         }
 
         public IReadOnlyList<AudioDeviceInfo> GetInputDevicesInfo()

--- a/CastorCore/Input/Audio/Device/AudioDeviceType.cs
+++ b/CastorCore/Input/Audio/Device/AudioDeviceType.cs
@@ -1,4 +1,4 @@
-﻿namespace CastorCore.Input
+﻿namespace CastorCore.Input.Audio.Device
 {
     public enum AudioDeviceType
     {

--- a/CastorCore/Input/Audio/IAudioInput.cs
+++ b/CastorCore/Input/Audio/IAudioInput.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace CastorCore.Input
+namespace CastorCore.Input.Audio
 {
     public interface IAudioInput
     {

--- a/CastorCore/Input/Video/Display/DxgiDisplayCapture.cs
+++ b/CastorCore/Input/Video/Display/DxgiDisplayCapture.cs
@@ -193,7 +193,7 @@ namespace CastorCore.Input.Video.Display
                         byte[] duplicatedData = new byte[lastFrameData.Length];
                         Array.Copy(lastFrameData, duplicatedData, lastFrameData.Length);
 
-                        IVideoFrame duplicatedFrame = new RawVideoFrame(Width, Height, duplicatedData);
+                        IVideoFrame duplicatedFrame = new RawVideoFrame(MediaTimestamp.Now(), Width, Height, duplicatedData);
                         framesDuplicated++;
 
                         if (_queue.Count < MAX_QUEUE_SIZE)
@@ -288,7 +288,7 @@ namespace CastorCore.Input.Video.Display
 
             _context.Unmap(_staging!, 0);
 
-            return new RawVideoFrame(Width, Height, buffer);
+            return new RawVideoFrame(MediaTimestamp.Now(), Width, Height, buffer);
         }
 
         public void Dispose()

--- a/CastorCore/Pipeline.cs
+++ b/CastorCore/Pipeline.cs
@@ -8,35 +8,43 @@ namespace CastorCore
     public sealed class Pipeline
     {
         private IVideoSource _videoSource;
+        private IAudioSource _audioSource;
 
         private IPipeSource _videoPipe;
+        private IPipeSource _audioPipe;
 
         private Mp4Encoder _encoder;
 
-        public Pipeline(IVideoSource videoSource)
+        public Pipeline(IVideoSource videoSource, IAudioSource audioSource)
         {
             _videoSource = videoSource ?? throw new ArgumentNullException(nameof(videoSource));
+            _audioSource = audioSource ?? throw new ArgumentNullException(nameof(videoSource));
+
             _videoPipe = _videoSource.ToPipeSource();
+            _audioPipe = _audioSource.ToPipeSource();
 
             string outputPath = $"output_{DateTime.Now:yyyyMMdd_HHmmss}.mp4";
 
-            _encoder = new Mp4Encoder(_videoPipe, outputPath);
+            _encoder = new Mp4Encoder(_videoPipe, _audioPipe, outputPath);
         }
 
-        public async Task Start(CancellationToken cts = default)
-        {
+        public async Task StartAsync(CancellationToken cts = default)
+        {   
             Console.WriteLine("[Pipeline] Starting video source...");
             _videoSource.StartCapture();
+            Console.WriteLine("[Pipeline] Starting audio source...");
+            _audioSource.StartCapture();
+
             Console.WriteLine("[Pipeline] Starting encoder...");
             await _encoder.StartAsync(cts);
-
-            return;
         }
 
-        public void Stop()
+        public async Task StopAsync()
         {
             Console.WriteLine("[Pipeline] Stopping video source...");
             _videoSource.StopCapture();
+            Console.WriteLine("[Pipeline] Stopping audio source...");
+            _audioSource.StopCapture();
         }
     }
 }

--- a/CastorCore/Pipeline.cs
+++ b/CastorCore/Pipeline.cs
@@ -1,0 +1,42 @@
+﻿using CastorCore.Encoder;
+using CastorCore.Source.Audio;
+using CastorCore.Source.Video;
+using FFMpegCore.Pipes;
+
+namespace CastorCore
+{
+    public sealed class Pipeline
+    {
+        private IVideoSource _videoSource;
+
+        private IPipeSource _videoPipe;
+
+        private Mp4Encoder _encoder;
+
+        public Pipeline(IVideoSource videoSource)
+        {
+            _videoSource = videoSource ?? throw new ArgumentNullException(nameof(videoSource));
+            _videoPipe = _videoSource.ToPipeSource();
+
+            string outputPath = $"output_{DateTime.Now:yyyyMMdd_HHmmss}.mp4";
+
+            _encoder = new Mp4Encoder(_videoPipe, outputPath);
+        }
+
+        public async Task Start(CancellationToken cts = default)
+        {
+            Console.WriteLine("[Pipeline] Starting video source...");
+            _videoSource.StartCapture();
+            Console.WriteLine("[Pipeline] Starting encoder...");
+            await _encoder.StartAsync(cts);
+
+            return;
+        }
+
+        public void Stop()
+        {
+            Console.WriteLine("[Pipeline] Stopping video source...");
+            _videoSource.StopCapture();
+        }
+    }
+}

--- a/CastorCore/Source/Audio/AudioSource.cs
+++ b/CastorCore/Source/Audio/AudioSource.cs
@@ -1,13 +1,8 @@
-﻿using CastorCore.Input;
+﻿using CastorCore.Input.Audio;
 using FFMpegCore.Pipes;
 using NAudio.Wave;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace CastorCore.Source
+namespace CastorCore.Source.Audio
 {
     public class AudioSource : IAudioSource
     {
@@ -18,6 +13,9 @@ namespace CastorCore.Source
             _input = input;
         }
 
+        public void StartCapture() => _input.StartCapture();
+        public void StopCapture() => _input.StopCapture();
+
         public IEnumerator<IAudioSample> GetAudioSamples()
         {
             foreach (IAudioSample sample in _input.PullSamples())
@@ -26,11 +24,11 @@ namespace CastorCore.Source
             }
         }
 
-        public RawAudioPipeSource ToPipeSource()
+        public IPipeSource ToPipeSource()
         {
             WaveFormat waveFormat = _input.Device.AudioClient.MixFormat;
 
-            RawAudioPipeSource rawAudioPipeSource = new RawAudioPipeSource(GetAudioSamples())
+            IPipeSource rawAudioPipeSource = new RawAudioPipeSource(GetAudioSamples())
             {
                 Channels = (uint)waveFormat.Channels,
                 SampleRate = (uint)waveFormat.SampleRate,

--- a/CastorCore/Source/Audio/AudioSourceFactory.cs
+++ b/CastorCore/Source/Audio/AudioSourceFactory.cs
@@ -1,0 +1,23 @@
+﻿using CastorCore.Input.Audio;
+using CastorCore.Input.Audio.Device;
+using NAudio.CoreAudioApi;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CastorCore.Source.Audio
+{
+    public class AudioSourceFactory
+    {
+        public static IAudioSource CreateDefaultOutputAudioSource()
+        {
+            AudioDeviceManager audioDeviceManager = new AudioDeviceManager();
+            MMDevice device = audioDeviceManager.GetDefaultOutputDevice();
+            WasapiAudioCapture audioInput = new WasapiAudioCapture(device);
+
+            return new AudioSource(audioInput);
+        }
+    }
+}

--- a/CastorCore/Source/Audio/IAudioSource.cs
+++ b/CastorCore/Source/Audio/IAudioSource.cs
@@ -1,10 +1,13 @@
 ﻿using FFMpegCore.Pipes;
 
-namespace CastorCore.Source
+namespace CastorCore.Source.Audio
 {
     public interface IAudioSource
     {
+        void StartCapture();
+        void StopCapture();
+
         IEnumerator<IAudioSample> GetAudioSamples();
-        RawAudioPipeSource ToPipeSource();
+        IPipeSource ToPipeSource();
     }
 }


### PR DESCRIPTION
This pull request introduces several major improvements and refactoring to the CastorCore media pipeline, focusing on consistent timestamping, modularization, and pipeline orchestration. The most significant changes are the addition of a unified `MediaTimestamp` type for audio and video frames, the creation of a new `Mp4Encoder` and `Pipeline` class for streamlined media processing, and a broad reorganization of namespaces for audio input and device management.

**Timestamping and Frame Consistency**

* Introduced the `MediaTimestamp` struct to provide unified, high-precision timestamps for both audio and video frames, replacing previous usage of `TimeSpan`. This change affects `AudioSample` and `RawVideoFrame` classes, ensuring consistent time tracking across media types. [[1]](diffhunk://#diff-1ac41a8e4acd8b41481ff6d7735a7b25d78e1c16d0bde472394ea2310b1a6a4cR1-R58) [[2]](diffhunk://#diff-115f2484ca54c321d22b220e3c2bab041818e4e2acd5d7821d0013867fbe627cL16-R27) [[3]](diffhunk://#diff-63b226c47478aaa77ed509e424e6fffb73632a369e4cc784276b2275598f50b6R9-R17) [[4]](diffhunk://#diff-b06d931ad55be20d7e9462da0bbba879f0f6234fe81793b391e0460cc8325308L196-R196) [[5]](diffhunk://#diff-b06d931ad55be20d7e9462da0bbba879f0f6234fe81793b391e0460cc8325308L291-R291)

**Pipeline and Encoder Orchestration**

* Added the new `Mp4Encoder` class leveraging FFMpegCore for encoding audio and video streams into MP4 format, and introduced the `Pipeline` class to orchestrate video/audio source capture and encoding. This enables a more modular and maintainable pipeline setup. [[1]](diffhunk://#diff-6f32c7d5761919854d6b17597e5ec7fbc8caf685b975cf3f4fbfa508a7d724b7R1-R43) [[2]](diffhunk://#diff-f5d4f1a5c489eea12eb7c40612667e23b51aba39b104834f878344f03c52b13dR1-R50)

**Audio Input and Device Management Refactor**

* Refactored audio input and device management code into new namespaces (`CastorCore.Input.Audio` and `CastorCore.Input.Audio.Device`), renamed files for clarity, and added methods to retrieve default input/output devices in `AudioDeviceManager`. [[1]](diffhunk://#diff-044555f898b0f32ecb4eba43286ec7651179a2674c779ded8a03568f03556397L1-R1) [[2]](diffhunk://#diff-bbf043796b9c175365579cced6f3eb887335a7c257b37328a102607f450544c3L9-R9) [[3]](diffhunk://#diff-bbf043796b9c175365579cced6f3eb887335a7c257b37328a102607f450544c3R29-R38) [[4]](diffhunk://#diff-8d24bc57082f5f56560cca8b31115d68f4f5cdc7cc847acfdeb65cac705bb4fdL1-R1) [[5]](diffhunk://#diff-73391389e1a6e807ae98705ea66419f47b536634f7c51fb56f0bdc7621d67b1eL9-R9)

**Source Abstractions and Factories**

* Updated `AudioSource` and `IAudioSource` interfaces to support explicit start/stop capture methods and to use the new timestamp and pipe source abstractions. Added an `AudioSourceFactory` for easy instantiation of default audio sources. [[1]](diffhunk://#diff-7c993ede0d65954b5fcfef33a67e919463b2e4bb976ed493f7522a5cb82398c3L1-R5) [[2]](diffhunk://#diff-7c993ede0d65954b5fcfef33a67e919463b2e4bb976ed493f7522a5cb82398c3R16-R18) [[3]](diffhunk://#diff-7c993ede0d65954b5fcfef33a67e919463b2e4bb976ed493f7522a5cb82398c3L29-R31) [[4]](diffhunk://#diff-274818df827cb7e10e54aa83c9c67b03b50d75fa825ccb1cb99578c7749ba0d7L3-R11) [[5]](diffhunk://#diff-3ba956cdc7e90252fcf290eca1d65181134015b74ed216a96e4f9a886cd82b1eR1-R23)

**Miscellaneous Fixes**

* Corrected disposal logic in `RawVideoFrame` and updated serialization methods to align with new timestamp and format conventions. [[1]](diffhunk://#diff-63b226c47478aaa77ed509e424e6fffb73632a369e4cc784276b2275598f50b6L45-R47) [[2]](diffhunk://#diff-115f2484ca54c321d22b220e3c2bab041818e4e2acd5d7821d0013867fbe627cL40-L43)

These changes collectively modernize the media pipeline, improve timestamp accuracy, and make the codebase more modular and maintainable.