### PR TITLE
chore: remove plugin settings from the settings view and view model

### DIFF
--- a/CastorApplication/ViewModels/SettingsViewModel.cs
+++ b/CastorApplication/ViewModels/SettingsViewModel.cs
@@ -27,9 +27,6 @@ public partial class SettingsViewModel : ViewModelBase
     [ObservableProperty]
     private bool _isAccountsActive;
 
-    [ObservableProperty]
-    private bool _isPluginsActive;
-
     // ── General settings ──
 
     [ObservableProperty]
@@ -164,9 +161,6 @@ public partial class SettingsViewModel : ViewModelBase
     [RelayCommand]
     private void ShowAccounts() { ResetCategories(); IsAccountsActive = true; }
 
-    [RelayCommand]
-    private void ShowPlugins() { ResetCategories(); IsPluginsActive = true; }
-
     private void ResetCategories()
     {
         IsGeneralActive = false;
@@ -175,7 +169,6 @@ public partial class SettingsViewModel : ViewModelBase
         IsStreamingActive = false;
         IsOutputActive = false;
         IsAccountsActive = false;
-        IsPluginsActive = false;
     }
 
     // ── Platform connection commands ──

--- a/CastorApplication/Views/SettingsView.axaml
+++ b/CastorApplication/Views/SettingsView.axaml
@@ -130,16 +130,6 @@
                             Classes="settings-nav" Content="Comptes"
                             Command="{Binding ShowAccountsCommand}"/>
 
-                    <!-- Plugins -->
-                    <Border IsVisible="{Binding IsPluginsActive}"
-                            Background="{DynamicResource AppAccentBg2}" BorderBrush="#5b8def" BorderThickness="3,0,0,0">
-                        <TextBlock Text="Plugins" Foreground="{DynamicResource AppFg1}" FontSize="13"
-                                   FontWeight="SemiBold" Margin="15,10"/>
-                    </Border>
-                    <Button IsVisible="{Binding !IsPluginsActive}"
-                            Classes="settings-nav" Content="Plugins"
-                            Command="{Binding ShowPluginsCommand}"/>
-
                 </StackPanel>
             </Grid>
         </Border>
@@ -439,29 +429,6 @@
                             <TextBlock Text="castor-studio.app"
                                        Foreground="#5b8def" FontSize="11" FontWeight="SemiBold"
                                        VerticalAlignment="Center" Cursor="Hand"/>
-                        </StackPanel>
-                    </Border>
-                </StackPanel>
-
-                <!-- ══ PLUGINS ══ -->
-                <StackPanel IsVisible="{Binding IsPluginsActive}" Spacing="14">
-                    <TextBlock Text="PLUGINS" Classes="section-title"/>
-
-                    <Border Background="{DynamicResource AppSurface}" BorderBrush="{DynamicResource AppBorder}" BorderThickness="1"
-                            CornerRadius="8" Padding="20">
-                        <StackPanel Spacing="12" HorizontalAlignment="Center">
-                            <TextBlock Text="Aucun plugin installé"
-                                       Foreground="{DynamicResource AppFg3}" FontSize="14" FontWeight="SemiBold"
-                                       HorizontalAlignment="Center"/>
-                            <TextBlock Text="Les plugins permettent d'ajouter des overlays, des effets&#x0a;et des fonctionnalités avancées à vos diffusions."
-                                       Foreground="{DynamicResource AppFg4}" FontSize="12"
-                                       HorizontalAlignment="Center" TextAlignment="Center"/>
-                            <Button Content="PARCOURIR SUR CASTOR-STUDIO.APP"
-                                    Background="{DynamicResource AppAccentBg}" Foreground="#5b8def"
-                                    BorderThickness="0" Padding="18,10" CornerRadius="6"
-                                    FontSize="12" FontWeight="SemiBold"
-                                    HorizontalAlignment="Center" Cursor="Hand"
-                                    Margin="0,4,0,0"/>
                         </StackPanel>
                     </Border>
                 </StackPanel>


### PR DESCRIPTION
This pull request removes the "Plugins" section from the settings UI and its related logic in the `SettingsViewModel`. The main changes include deleting the view and command logic for the Plugins tab, as well as all associated UI elements.

**Removal of Plugins section:**

* Removed the `_isPluginsActive` property and all logic related to activating the Plugins section from `SettingsViewModel.cs`. [[1]](diffhunk://#diff-e5fe12b77b41fcba02e36f9cd5f1f7c2eda3729ae97e010fb9c577c88ddf25beL30-L32) [[2]](diffhunk://#diff-e5fe12b77b41fcba02e36f9cd5f1f7c2eda3729ae97e010fb9c577c88ddf25beL167-L169) [[3]](diffhunk://#diff-e5fe12b77b41fcba02e36f9cd5f1f7c2eda3729ae97e010fb9c577c88ddf25beL178)
* Deleted the "Plugins" navigation button, content panel, and all UI elements related to plugins from `SettingsView.axaml`. [[1]](diffhunk://#diff-5271694d4081f9840be71fcc7f998b3b438814a73299ecc97151ea525cddf6bcL133-L142) [[2]](diffhunk://#diff-5271694d4081f9840be71fcc7f998b3b438814a73299ecc97151ea525cddf6bcL446-L468)