### PR TITLE
Bug/fixing issues

### DIFF
--- a/CastorApplication/Models/Settings/ApplicationSettings.cs
+++ b/CastorApplication/Models/Settings/ApplicationSettings.cs
@@ -26,4 +26,11 @@ public sealed class ApplicationSettings
 
     public int SelectedOutputFormatIndex { get; set; }
     public string OutputPath { get; set; } = "";
+
+    /* ── Lecture (preview player) ── */
+    /// <summary>Volume du player de prévisualisation, de 0 à 100.</summary>
+    public double PlayerVolume { get; set; } = 80;
+
+    /// <summary>Coupe automatiquement le son du player quand un enregistrement ou un live démarre.</summary>
+    public bool MutePlayersOnRecord { get; set; } = true;
 }

--- a/CastorApplication/Services/RecorderService.cs
+++ b/CastorApplication/Services/RecorderService.cs
@@ -41,6 +41,12 @@ public sealed class RecorderService
     public bool IsRecording => _recorderPtr != IntPtr.Zero;
     public bool IsStreaming => _streamPtr   != IntPtr.Zero;
 
+    // ── Events d'état (abonnés par ScenesViewModel pour l'auto-mute) ──────────
+    public event Action? RecordingStarted;
+    public event Action? RecordingStopped;
+    public event Action? StreamingStarted;
+    public event Action? StreamingStopped;
+
     /// <summary>Retourne true si un flux de preview est actif pour cette scène.</summary>
     public bool IsPreviewActive(Guid sceneId)
     {
@@ -102,6 +108,7 @@ public sealed class RecorderService
             return result;
         }
 
+        RecordingStarted?.Invoke();
         return 0;
     }
 
@@ -115,6 +122,7 @@ public sealed class RecorderService
         CastorNative.RecorderStop(_recorderPtr);
         CastorNative.RecorderDestroy(_recorderPtr);
         _recorderPtr = IntPtr.Zero;
+        RecordingStopped?.Invoke();
     }
 
     /// <summary>
@@ -188,6 +196,7 @@ public sealed class RecorderService
             return result;
         }
 
+        StreamingStarted?.Invoke();
         return 0;
     }
 
@@ -198,6 +207,7 @@ public sealed class RecorderService
         CastorNative.RecorderStop(_streamPtr);
         CastorNative.RecorderDestroy(_streamPtr);
         _streamPtr = IntPtr.Zero;
+        StreamingStopped?.Invoke();
     }
 
     // ── Preview local (MediaMTX) — un flux indépendant par scène ─────────────
@@ -252,7 +262,10 @@ public sealed class RecorderService
                     Destination      = MediaMtxService.GetPreviewPushUrl(scene.Id),
                     VideoBitrateKbps = 3000,
                     AudioBitrateKbps = 128,
-                    GopSeconds       = 1,
+                    // GopSeconds = 0 : en mode zerolatency, VideoEncode.c utilise
+                    // fps/2 frames (0,5 s à 30 fps) → IDR plus fréquents, VLC
+                    // peut rejoindre le flux plus vite après une reconnexion.
+                    GopSeconds       = 0,
                 }
             };
 

--- a/CastorApplication/Services/RecorderService.cs
+++ b/CastorApplication/Services/RecorderService.cs
@@ -31,6 +31,13 @@ public sealed class RecorderService
     /// </summary>
     private readonly SemaphoreSlim _previewSemaphore = new(1, 1);
 
+    /// <summary>
+    /// Sérialise les appels à SwitchScene : si deux switches arrivent très vite,
+    /// le second attend que le premier appel natif soit terminé pour éviter un
+    /// appel concurrent à RecorderSwitchVideoSource sur le même pointeur.
+    /// </summary>
+    private readonly SemaphoreSlim _switchSemaphore = new(1, 1);
+
     public bool IsRecording => _recorderPtr != IntPtr.Zero;
     public bool IsStreaming => _streamPtr   != IntPtr.Zero;
 
@@ -334,24 +341,31 @@ public sealed class RecorderService
 
     /// <summary>
     /// Change la source vidéo à la volée sur les recorders actifs (enregistrement et stream).
-    /// Doit être appelé depuis un thread background pour ne pas bloquer le UI
-    /// et éviter les conflits WinRT lors de la réinitialisation de la capture.
-    /// Le preview est géré séparément via StartPreview().
+    /// Sérialisé via _switchSemaphore : si deux switches rapides arrivent, le second
+    /// attend la fin du premier pour éviter un appel concurrent sur le même pointeur natif.
     /// </summary>
     public int SwitchScene(SceneItem scene)
     {
-        var videoItem = scene.Sources.FirstOrDefault(s => s.Type == "Vidéo" && s.Tag is CaptureSourceInfo);
-        if (videoItem == null) return -1;
+        _switchSemaphore.Wait();
+        try
+        {
+            var videoItem = scene.Sources.FirstOrDefault(s => s.Type == "Vidéo" && s.Tag is CaptureSourceInfo);
+            if (videoItem == null) return -1;
 
-        var videoSrc = (CaptureSourceInfo)videoItem.Tag!;
-        int result = 0;
+            var videoSrc = (CaptureSourceInfo)videoItem.Tag!;
+            int result = 0;
 
-        if (IsRecording)
-            result = CastorNative.RecorderSwitchVideoSource(_recorderPtr, streamIndex: 0, videoSrc);
+            if (IsRecording)
+                result = CastorNative.RecorderSwitchVideoSource(_recorderPtr, streamIndex: 0, videoSrc);
 
-        if (IsStreaming && result == 0)
-            result = CastorNative.RecorderSwitchVideoSource(_streamPtr, streamIndex: 0, videoSrc);
+            if (IsStreaming && result == 0)
+                result = CastorNative.RecorderSwitchVideoSource(_streamPtr, streamIndex: 0, videoSrc);
 
-        return result;
+            return result;
+        }
+        finally
+        {
+            _switchSemaphore.Release();
+        }
     }
 }

--- a/CastorApplication/ViewModels/SceneViewModel.cs
+++ b/CastorApplication/ViewModels/SceneViewModel.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Castor.Native;
 using CastorApplication.Models;
 using CastorApplication.Services;
+using CastorApplication.Services.Settings;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -30,10 +31,47 @@ public partial class ScenesViewModel : ViewModelBase
     public ObservableCollection<AudioSourceOption>   AvailableLoopbacks { get; } = new();
     public ObservableCollection<AudioSourceOption>   AvailableMics      { get; } = new();
 
+    // ── Player preview (volume + mute auto) ─────────────────────────────────
+
+    [ObservableProperty]
+    private double _playerVolume = 80;
+
+    [ObservableProperty]
+    private bool _mutePlayersOnRecord = true;
+
+    private double _savedPlayerVolume = 80;
+    private bool _mutedForCapture;
+
+    private void ApplyAutoMute()
+    {
+        if (!MutePlayersOnRecord || _mutedForCapture) return;
+        _savedPlayerVolume = PlayerVolume;
+        PlayerVolume       = 0;
+        _mutedForCapture   = true;
+    }
+
+    private void RestoreAutoMute()
+    {
+        if (!_mutedForCapture) return;
+        if (RecorderService.Instance.IsRecording || RecorderService.Instance.IsStreaming) return;
+        PlayerVolume     = _savedPlayerVolume;
+        _mutedForCapture = false;
+    }
+
     // ── Constructeur ─────────────────────────────────────────────────────────
 
-    public ScenesViewModel()
+    public ScenesViewModel(SettingsService settingsService)
     {
+        var settings     = settingsService.Load();
+        _playerVolume        = settings.PlayerVolume;
+        _mutePlayersOnRecord = settings.MutePlayersOnRecord;
+        _savedPlayerVolume   = _playerVolume;
+
+        RecorderService.Instance.RecordingStarted  += ApplyAutoMute;
+        RecorderService.Instance.RecordingStopped  += RestoreAutoMute;
+        RecorderService.Instance.StreamingStarted  += ApplyAutoMute;
+        RecorderService.Instance.StreamingStopped  += RestoreAutoMute;
+
         // Synchronise la sélection UI avec la scène active du service
         SelectedScene = SceneService.Instance.ActiveScene;
 

--- a/CastorApplication/ViewModels/Settings/Sections/AudioSettingsViewModel.cs
+++ b/CastorApplication/ViewModels/Settings/Sections/AudioSettingsViewModel.cs
@@ -14,11 +14,27 @@ public partial class AudioSettingsViewModel : SettingsSectionViewModel
     [ObservableProperty]
     private int _selectedAudioBitrateIndex = 1;
 
+    // ── Lecture (preview player) ──────────────────────────────────────────────
+
+    /// <summary>Volume du player de prévisualisation (0–100).</summary>
+    [ObservableProperty]
+    private double _playerVolume = 80;
+
+    /// <summary>Coupe le son du player dès qu'un enregistrement ou un live démarre.</summary>
+    [ObservableProperty]
+    private bool _mutePlayersOnRecord = true;
+
+    public string PlayerVolumeLabel => $"{(int)PlayerVolume}%";
+
+    partial void OnPlayerVolumeChanged(double value) => OnPropertyChanged(nameof(PlayerVolumeLabel));
+
     protected override void LoadCore(ApplicationSettings settings)
     {
         SelectedSampleRateIndex = settings.SelectedSampleRateIndex;
         SelectedChannelsIndex = settings.SelectedChannelsIndex;
         SelectedAudioBitrateIndex = settings.SelectedAudioBitrateIndex;
+        PlayerVolume = settings.PlayerVolume;
+        MutePlayersOnRecord = settings.MutePlayersOnRecord;
     }
 
     protected override void SaveCore(ApplicationSettings settings)
@@ -26,5 +42,7 @@ public partial class AudioSettingsViewModel : SettingsSectionViewModel
         settings.SelectedSampleRateIndex = SelectedSampleRateIndex;
         settings.SelectedChannelsIndex = SelectedChannelsIndex;
         settings.SelectedAudioBitrateIndex = SelectedAudioBitrateIndex;
+        settings.PlayerVolume = PlayerVolume;
+        settings.MutePlayersOnRecord = MutePlayersOnRecord;
     }
 }

--- a/CastorApplication/ViewModels/StudioViewModel.cs
+++ b/CastorApplication/ViewModels/StudioViewModel.cs
@@ -12,6 +12,7 @@ using CastorApplication.Factories;
 using CastorApplication.Models;
 using CastorApplication.Services;
 using CastorApplication.Services.Auth.Storage;
+using CastorApplication.Services.Settings;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Dock.Model.Controls;
@@ -72,6 +73,39 @@ public partial class StudioViewModel : ViewModelBase
     partial void OnDesktopVolumeChanged(double value) => OnPropertyChanged(nameof(DesktopVolumeDisplay));
     partial void OnMicVolumeChanged(double value) => OnPropertyChanged(nameof(MicVolumeDisplay));
     partial void OnMusicVolumeChanged(double value) => OnPropertyChanged(nameof(MusicVolumeDisplay));
+
+    // ── Player preview (volume + mute auto) ──────────────────────────────────
+
+    /// <summary>Volume du player de prévisualisation VLC (0–100).</summary>
+    [ObservableProperty]
+    private double _playerVolume = 80;
+
+    /// <summary>Quand true, le player est automatiquement coupé à l'entrée en record/live.</summary>
+    [ObservableProperty]
+    private bool _mutePlayersOnRecord = true;
+
+    /// <summary>Volume sauvegardé avant le mute automatique, pour restauration à l'arrêt.</summary>
+    private double _savedPlayerVolume = 80;
+
+    /// <summary>Indique que le mute automatique est actuellement actif.</summary>
+    private bool _mutedForCapture;
+
+    private void ApplyAutoMute()
+    {
+        if (!MutePlayersOnRecord || _mutedForCapture) return;
+        _savedPlayerVolume = PlayerVolume;
+        PlayerVolume       = 0;
+        _mutedForCapture   = true;
+    }
+
+    private void RestoreAutoMute()
+    {
+        if (!_mutedForCapture) return;
+        // Restaure uniquement quand ni recording ni streaming ne sont actifs
+        if (IsRecording || IsStreaming) return;
+        PlayerVolume     = _savedPlayerVolume;
+        _mutedForCapture = false;
+    }
 
     // ── Streaming state (F1) ──
 
@@ -175,9 +209,16 @@ public partial class StudioViewModel : ViewModelBase
 
     private readonly IProviderStore _providerStore;
 
-    public StudioViewModel(IProviderStore providerStore)
+    public StudioViewModel(IProviderStore providerStore, SettingsService settingsService)
     {
         _providerStore = providerStore;
+
+        // Charge les valeurs de lecture depuis les paramètres persistés
+        var settings = settingsService.Load();
+        _playerVolume        = settings.PlayerVolume;
+        _mutePlayersOnRecord = settings.MutePlayersOnRecord;
+        _savedPlayerVolume   = _playerVolume;
+
         RefreshProviderState(_streamPlatformIndex);
         var factory = new StudioDockFactory(this);
         Layout = factory.CreateLayout();
@@ -296,7 +337,10 @@ public partial class StudioViewModel : ViewModelBase
         int result = await Task.Run(() => RecorderService.Instance.StartStream(scene, service, keyOrUrl));
 
         if (result == 0)
+        {
             IsStreaming = true;
+            ApplyAutoMute();
+        }
         else
             StreamError = result switch
             {
@@ -312,6 +356,7 @@ public partial class StudioViewModel : ViewModelBase
     {
         RecorderService.Instance.StopStream();
         IsStreaming = false;
+        RestoreAutoMute();
     }
 
     // ── Recording commands ──
@@ -335,6 +380,7 @@ public partial class StudioViewModel : ViewModelBase
         if (result == 0)
         {
             IsRecording = true;
+            ApplyAutoMute();
         }
         else
         {
@@ -352,6 +398,7 @@ public partial class StudioViewModel : ViewModelBase
     {
         RecorderService.Instance.StopRecording();
         IsRecording = false;
+        RestoreAutoMute();
     }
 
     private static async Task<string?> PickOutputFileAsync()

--- a/CastorApplication/Views/ScenesView.axaml.cs
+++ b/CastorApplication/Views/ScenesView.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -16,9 +17,11 @@ public partial class ScenesView : UserControl
     private LibVLC? _libVLC;
     private MediaPlayer? _mediaPlayer;
     private Media? _currentMedia;
-
-    // Garde une référence sur le ViewModel pour se désabonner proprement
     private ScenesViewModel? _vm;
+
+    private volatile bool _isDisposed;
+    private readonly object _playLock = new();
+    private CancellationTokenSource _playCts = new();
 
     public ScenesView()
     {
@@ -27,20 +30,34 @@ public partial class ScenesView : UserControl
         try { LibVLCSharp.Shared.Core.Initialize(); }
         catch (Exception ex) { Debug.WriteLine($"[ScenesPreview] Erreur init VLC : {ex.Message}"); }
 
-        _libVLC      = new LibVLC("--network-caching=150");
+        _libVLC = new LibVLC(
+            "--network-caching=50",
+            "--live-caching=50",
+            "--clock-jitter=0",
+            "--clock-synchro=0"
+        );
         _mediaPlayer = new MediaPlayer(_libVLC);
 
-        // Retry automatique si le flux n'est pas encore dispo ou se coupe
         _mediaPlayer.EncounteredError += async (_, _) =>
         {
-            await Task.Delay(2000).ConfigureAwait(false);
-            PlayScenePreview(GetSelectedScene());
+            if (_isDisposed) return;
+            var cts = _playCts;
+            try { await Task.Delay(2000, cts.Token).ConfigureAwait(false); }
+            catch (Exception) { return; }
+            if (_isDisposed) return;
+            var scene = _vm?.SelectedScene;
+            if (scene != null) EnsureScenePreview(scene);
+            PlayScenePreview(_vm?.SelectedScene);
         };
 
         _mediaPlayer.EndReached += async (_, _) =>
         {
-            await Task.Delay(1000).ConfigureAwait(false);
-            PlayScenePreview(GetSelectedScene());
+            if (_isDisposed) return;
+            var cts = _playCts;
+            try { await Task.Delay(1000, cts.Token).ConfigureAwait(false); }
+            catch (Exception) { return; }
+            if (_isDisposed) return;
+            PlayScenePreview(_vm?.SelectedScene);
         };
 
         DataContextChanged += OnDataContextChanged;
@@ -50,7 +67,6 @@ public partial class ScenesView : UserControl
 
     private void OnDataContextChanged(object? sender, EventArgs e)
     {
-        // Désabonnement de l'ancien VM
         if (_vm != null)
             _vm.PropertyChanged -= OnVmPropertyChanged;
 
@@ -60,7 +76,9 @@ public partial class ScenesView : UserControl
         {
             _vm.PropertyChanged += OnVmPropertyChanged;
 
-            // Lance le preview de la scène déjà sélectionnée (si applicable)
+            if (_mediaPlayer != null)
+                _mediaPlayer.Volume = (int)_vm.PlayerVolume;
+
             if (_vm.SelectedScene != null)
                 EnsureScenePreview(_vm.SelectedScene);
         }
@@ -68,8 +86,28 @@ public partial class ScenesView : UserControl
 
     private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(ScenesViewModel.SelectedScene) && _vm?.SelectedScene != null)
-            EnsureScenePreview(_vm.SelectedScene);
+        if (e.PropertyName == nameof(ScenesViewModel.PlayerVolume))
+        {
+            if (_mediaPlayer != null && _vm != null)
+                _mediaPlayer.Volume = (int)_vm.PlayerVolume;
+            return;
+        }
+
+        if (e.PropertyName != nameof(ScenesViewModel.SelectedScene)) return;
+        if (_vm?.SelectedScene == null) return;
+
+        var newCts = new CancellationTokenSource();
+        var oldCts = Interlocked.Exchange(ref _playCts, newCts);
+        oldCts.Cancel();
+        oldCts.Dispose();
+
+        var scene = _vm.SelectedScene;
+        _ = Task.Run(() =>
+        {
+            EnsureScenePreview(scene);
+            if (!newCts.IsCancellationRequested)
+                PlayScenePreview(scene);
+        });
     }
 
     // ── Gestion du preview ────────────────────────────────────────────────────
@@ -78,21 +116,17 @@ public partial class ScenesView : UserControl
     {
         if (RecorderService.Instance.IsPreviewActive(scene.Id))
         {
-            // Le flux tourne déjà — on branche directement VLC dessus
             PlayScenePreview(scene);
             return;
         }
 
-        // Pas encore actif — démarre en background (le sémaphore dans RecorderService
-        // garantit qu'un seul Start peut s'exécuter à la fois, même si plusieurs
-        // threads arrivent ici simultanément).
         _ = Task.Run(async () =>
         {
             int r = RecorderService.Instance.StartPreview(scene);
             Debug.WriteLine($"[ScenesPreview] StartPreview '{scene.Name}' : {r}");
             if (r == 0)
             {
-                await Task.Delay(600).ConfigureAwait(false); // laisse le flux s'établir
+                await Task.Delay(600).ConfigureAwait(false);
                 PlayScenePreview(scene);
             }
         });
@@ -100,16 +134,20 @@ public partial class ScenesView : UserControl
 
     private void PlayScenePreview(SceneItem? scene)
     {
-        if (scene == null || _libVLC == null || _mediaPlayer == null) return;
+        if (_isDisposed || scene == null || _libVLC == null || _mediaPlayer == null) return;
 
         var url = MediaMtxService.GetPreviewPullUrl(scene.Id);
-        var old = _currentMedia;
-        _currentMedia = new Media(_libVLC, new Uri(url), ":network-caching=150");
-        _mediaPlayer.Play(_currentMedia);
+
+        Media? old;
+        lock (_playLock)
+        {
+            if (_isDisposed) return;
+            old           = _currentMedia;
+            _currentMedia = new Media(_libVLC, new Uri(url), ":network-caching=150");
+            _mediaPlayer.Play(_currentMedia);
+        }
         old?.Dispose();
     }
-
-    private SceneItem? GetSelectedScene() => _vm?.SelectedScene;
 
     // ── Attachement du VideoView ──────────────────────────────────────────────
 
@@ -120,8 +158,10 @@ public partial class ScenesView : UserControl
             if (videoView.MediaPlayer == null)
                 videoView.MediaPlayer = _mediaPlayer;
 
-            // Si une scène est déjà sélectionnée, lance son preview
-            var scene = GetSelectedScene();
+            if (_vm != null)
+                _mediaPlayer.Volume = (int)_vm.PlayerVolume;
+
+            var scene = _vm?.SelectedScene;
             if (scene != null && !_mediaPlayer.IsPlaying)
                 EnsureScenePreview(scene);
         }
@@ -132,6 +172,10 @@ public partial class ScenesView : UserControl
     protected override void OnUnloaded(Avalonia.Interactivity.RoutedEventArgs e)
     {
         base.OnUnloaded(e);
+
+        _isDisposed = true;
+        _playCts.Cancel();
+        _playCts.Dispose();
 
         if (_vm != null)
         {
@@ -148,12 +192,16 @@ public partial class ScenesView : UserControl
             if (_mediaPlayer.IsPlaying)
                 _mediaPlayer.Stop();
 
-            _currentMedia?.Dispose();
-            _currentMedia = null;
-            _mediaPlayer.Dispose();
-            _libVLC?.Dispose();
+            lock (_playLock)
+            {
+                _currentMedia?.Dispose();
+                _currentMedia = null;
+            }
 
+            _mediaPlayer.Dispose();
             _mediaPlayer = null;
+
+            _libVLC?.Dispose();
             _libVLC = null;
         }
     }

--- a/CastorApplication/Views/Settings/Sections/AudioSettingsView.axaml
+++ b/CastorApplication/Views/Settings/Sections/AudioSettingsView.axaml
@@ -70,6 +70,53 @@
 
         </StackPanel>
 
+        <!-- ── LECTURE ── -->
+        <StackPanel Spacing="14">
+
+            <TextBlock Text="LECTURE"
+                       Classes="section-title"/>
+
+            <!-- Slider volume preview -->
+            <Grid ColumnDefinitions="180,*">
+
+                <TextBlock Grid.Column="0"
+                           Text="Volume de prévisualisation"
+                           Classes="setting-label"/>
+
+                <StackPanel Grid.Column="1"
+                            Spacing="6"
+                            MaxWidth="260">
+
+                    <Slider Minimum="0"
+                            Maximum="100"
+                            Value="{Binding PlayerVolume}"
+                            TickFrequency="5"
+                            IsSnapToTickEnabled="True"/>
+
+                    <TextBlock Text="{Binding PlayerVolumeLabel}"
+                               Foreground="{DynamicResource AppFg4}"
+                               FontSize="11"/>
+
+                </StackPanel>
+
+            </Grid>
+
+            <!-- Checkbox mute auto -->
+            <Grid ColumnDefinitions="180,*">
+
+                <TextBlock Grid.Column="0"
+                           Text="Couper le son en enregistrement / live"
+                           Classes="setting-label"
+                           TextWrapping="Wrap"/>
+
+                <CheckBox Grid.Column="1"
+                          IsChecked="{Binding MutePlayersOnRecord}"
+                          VerticalAlignment="Center"/>
+
+            </Grid>
+
+        </StackPanel>
+
     </StackPanel>
 
 </UserControl>

--- a/CastorApplication/Views/StudioView.axaml.cs
+++ b/CastorApplication/Views/StudioView.axaml.cs
@@ -40,24 +40,36 @@ namespace CastorApplication.Views
             {
                 LibVLCSharp.Shared.Core.Initialize();
 
-                _libVLC      = new LibVLC("--network-caching=150");
+                _libVLC      = new LibVLC(
+                    "--network-caching=50",   // réduit de 150 → 50 ms
+                    "--live-caching=50",       // cache dédié aux flux RTMP live
+                    "--clock-jitter=0",        // désactive la compensation de jitter (ajoute du délai)
+                    "--clock-synchro=0"        // désactive la re-sync PTS (source de buffering supplémentaire)
+                );
                 _mediaPlayer = new MediaPlayer(_libVLC);
 
                 // Retry automatique si le flux n'est pas encore disponible ou se coupe.
-                // On passe le CTS courant pour ne pas rejouer si on a déjà switché de scène.
+                // On reappelle EnsurePreviewRunning() pour relancer le recorder si
+                // le démarrage initial a échoué (MediaMTX pas encore prêt, capture lente…).
                 _mediaPlayer.EncounteredError += async (_, _) =>
                 {
+                    if (_isDisposed) return;
                     var cts = _playCts;
                     try { await Task.Delay(2000, cts.Token).ConfigureAwait(false); }
-                    catch (OperationCanceledException) { return; }
+                    catch (Exception) { return; }   // OperationCanceledException ou ObjectDisposedException
+                    if (_isDisposed) return;
+                    _vm?.EnsurePreviewRunning();    // repart le recorder s'il avait échoué
                     PlayPreview();
                 };
 
                 _mediaPlayer.EndReached += async (_, _) =>
                 {
+                    if (_isDisposed) return;
                     var cts = _playCts;
                     try { await Task.Delay(1000, cts.Token).ConfigureAwait(false); }
-                    catch (OperationCanceledException) { return; }
+                    catch (Exception) { return; }
+                    if (_isDisposed) return;
+                    _vm?.EnsurePreviewRunning();
                     PlayPreview();
                 };
             }

--- a/CastorApplication/Views/StudioView.axaml.cs
+++ b/CastorApplication/Views/StudioView.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Markup.Xaml;
 using LibVLCSharp.Shared;
 using LibVLCSharp.Avalonia;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using CastorApplication.Services;
 using CastorApplication.ViewModels;
@@ -16,15 +17,23 @@ namespace CastorApplication.Views
         private MediaPlayer? _mediaPlayer;
         private Media? _currentMedia;
         private StudioViewModel? _vm;
+
         // Flag pour éviter tout appel natif VLC après libération des ressources
         private volatile bool _isDisposed;
+
+        // ── Thread-safety de PlayPreview ─────────────────────────────────────────
+        // Sérialise les swaps de Media pour éviter double-dispose et appels Play
+        // concurrents depuis les callbacks VLC, les Task.Run de switching et l'UI thread.
+        private readonly object _playLock = new();
+
+        // Permet d'annuler un PlayPreview différé quand un deuxième switch arrive
+        // avant que le délai d'attente soit écoulé.
+        private CancellationTokenSource _playCts = new();
 
         public StudioView()
         {
             InitializeComponent();
 
-            // DataContextChanged est toujours enregistré : même sans VLC on doit
-            // suivre les changements de scène pour d'éventuelles futures tentatives.
             DataContextChanged += OnDataContextChanged;
 
             try
@@ -34,25 +43,27 @@ namespace CastorApplication.Views
                 _libVLC      = new LibVLC("--network-caching=150");
                 _mediaPlayer = new MediaPlayer(_libVLC);
 
-                // Retry automatique si le flux n'est pas encore disponible ou se coupe
-                // ConfigureAwait(false) pour sortir du thread d'événement VLC avant de rappeler Play
+                // Retry automatique si le flux n'est pas encore disponible ou se coupe.
+                // On passe le CTS courant pour ne pas rejouer si on a déjà switché de scène.
                 _mediaPlayer.EncounteredError += async (_, _) =>
                 {
-                    await Task.Delay(2000).ConfigureAwait(false);
+                    var cts = _playCts;
+                    try { await Task.Delay(2000, cts.Token).ConfigureAwait(false); }
+                    catch (OperationCanceledException) { return; }
                     PlayPreview();
                 };
 
                 _mediaPlayer.EndReached += async (_, _) =>
                 {
-                    await Task.Delay(1000).ConfigureAwait(false);
+                    var cts = _playCts;
+                    try { await Task.Delay(1000, cts.Token).ConfigureAwait(false); }
+                    catch (OperationCanceledException) { return; }
                     PlayPreview();
                 };
             }
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"Erreur d'initialisation VLC : {ex.Message}");
-                // _libVLC et _mediaPlayer restent null — PlayPreview() et VideoView_OnAttached
-                // vérifient null avant tout appel natif.
             }
         }
 
@@ -69,7 +80,7 @@ namespace CastorApplication.Views
 
         private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            // Volume du player : appliqué immédiatement à VLC (0-100 → VLC accepte 0-200)
+            // Volume du player : appliqué immédiatement à VLC (0–100)
             if (e.PropertyName == nameof(StudioViewModel.PlayerVolume))
             {
                 if (_mediaPlayer != null && _vm != null)
@@ -79,20 +90,29 @@ namespace CastorApplication.Views
 
             if (e.PropertyName != nameof(StudioViewModel.ActiveScene)) return;
 
-            // La scène active a changé : démarre son preview si nécessaire, puis bascule VLC sur son URL.
-            _ = Task.Run(async () =>
+            // Scène active changée :
+            //   1. Annule tout PlayPreview différé en cours (switch précédent pas encore joué).
+            //   2. Lance le preview de la nouvelle scène si nécessaire.
+            //   3. Bascule VLC immédiatement → si le flux n'est pas prêt, le retry prend le relais.
+            var newCts = new CancellationTokenSource();
+            var oldCts = Interlocked.Exchange(ref _playCts, newCts);
+            oldCts.Cancel();
+            oldCts.Dispose();
+
+            _ = Task.Run(() =>
             {
-                var scene = SceneService.Instance.ActiveScene;
-                bool alreadyRunning = scene != null && RecorderService.Instance.IsPreviewActive(scene.Id);
                 _vm?.EnsurePreviewRunning();
-                // Délai uniquement si le recorder vient d'être créé (laisse le stream s'établir).
-                // Si le preview tournait déjà, on bascule VLC immédiatement.
-                if (!alreadyRunning)
-                    await Task.Delay(1200).ConfigureAwait(false);
-                PlayPreview();
+                // On joue immédiatement : le retry EncounteredError gère le cas où
+                // le flux MediaMTX n'est pas encore prêt, sans créer de fenêtre de désync.
+                if (!newCts.IsCancellationRequested)
+                    PlayPreview();
             });
         }
 
+        /// <summary>
+        /// Swaps atomiquement le Media VLC vers l'URL de la scène active.
+        /// Thread-safe : peut être appelé depuis n'importe quel thread.
+        /// </summary>
         private void PlayPreview()
         {
             if (_isDisposed || _libVLC == null || _mediaPlayer == null) return;
@@ -101,9 +121,16 @@ namespace CastorApplication.Views
             if (scene == null) return;
 
             var url = MediaMtxService.GetPreviewPullUrl(scene.Id);
-            var old = _currentMedia;
-            _currentMedia = new Media(_libVLC, new Uri(url), ":network-caching=150");
-            _mediaPlayer.Play(_currentMedia);
+
+            Media? old;
+            lock (_playLock)
+            {
+                if (_isDisposed) return;   // re-check sous le verrou
+                old           = _currentMedia;
+                _currentMedia = new Media(_libVLC, new Uri(url), ":network-caching=150");
+                _mediaPlayer.Play(_currentMedia);
+            }
+            // Dispose hors du verrou pour ne pas bloquer d'autres appels entrants
             old?.Dispose();
         }
 
@@ -114,10 +141,8 @@ namespace CastorApplication.Views
                 if (videoView.MediaPlayer == null)
                     videoView.MediaPlayer = _mediaPlayer;
 
-                // S'assure que libcastor pousse vers MediaMTX avant de lire
                 if (DataContext is StudioViewModel vm)
                 {
-                    // Applique le volume persisté dès l'attachement du player
                     _mediaPlayer.Volume = (int)vm.PlayerVolume;
                     vm.EnsurePreviewRunning();
                 }
@@ -131,9 +156,12 @@ namespace CastorApplication.Views
         {
             base.OnUnloaded(e);
 
-            // Bloque immédiatement tout nouvel appel à PlayPreview() venant des
-            // callbacks VLC (EncounteredError / EndReached) encore en vol.
+            // 1. Bloque tout nouveau PlayPreview venant des callbacks VLC en vol.
             _isDisposed = true;
+
+            // 2. Annule les retries/delays en attente.
+            _playCts.Cancel();
+            _playCts.Dispose();
 
             if (_vm != null)
             {
@@ -143,18 +171,20 @@ namespace CastorApplication.Views
 
             if (_mediaPlayer != null)
             {
-                // 1. On détache le lien avec le contrôle visuel (CRITIQUE)
                 var videoView = this.FindControl<VideoView>("VideoPlayer");
                 if (videoView != null)
                     videoView.MediaPlayer = null;
 
-                // 2. On arrête le flux
                 if (_mediaPlayer.IsPlaying)
                     _mediaPlayer.Stop();
 
-                // 3. On libère dans l'ordre
-                _currentMedia?.Dispose();
-                _currentMedia = null;
+                // Acquiert le verrou pour s'assurer qu'aucun PlayPreview n'est en cours
+                // avant de libérer les ressources.
+                lock (_playLock)
+                {
+                    _currentMedia?.Dispose();
+                    _currentMedia = null;
+                }
 
                 _mediaPlayer.Dispose();
                 _mediaPlayer = null;

--- a/CastorApplication/Views/StudioView.axaml.cs
+++ b/CastorApplication/Views/StudioView.axaml.cs
@@ -69,6 +69,14 @@ namespace CastorApplication.Views
 
         private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
+            // Volume du player : appliqué immédiatement à VLC (0-100 → VLC accepte 0-200)
+            if (e.PropertyName == nameof(StudioViewModel.PlayerVolume))
+            {
+                if (_mediaPlayer != null && _vm != null)
+                    _mediaPlayer.Volume = (int)_vm.PlayerVolume;
+                return;
+            }
+
             if (e.PropertyName != nameof(StudioViewModel.ActiveScene)) return;
 
             // La scène active a changé : démarre son preview si nécessaire, puis bascule VLC sur son URL.
@@ -108,7 +116,11 @@ namespace CastorApplication.Views
 
                 // S'assure que libcastor pousse vers MediaMTX avant de lire
                 if (DataContext is StudioViewModel vm)
+                {
+                    // Applique le volume persisté dès l'attachement du player
+                    _mediaPlayer.Volume = (int)vm.PlayerVolume;
                     vm.EnsurePreviewRunning();
+                }
 
                 if (!_mediaPlayer.IsPlaying)
                     PlayPreview();

--- a/libcastor/include/AudioCapture.h
+++ b/libcastor/include/AudioCapture.h
@@ -52,6 +52,11 @@ typedef struct {
 extern "C" {
 #endif
 
+/* Capture audio uniquement du process associe au hwnd donne,
+ * via le Windows Process Loopback API (Windows 10 2004+, build 19041).
+ * Retourne 0 si succes, -1 si erreur. */
+CASTOR_CORE_API int audio_capture_init_process_loopback(AudioCaptureContext* ctx, void* hwnd);
+
 /* Liste les devices audio WASAPI bruts (legacy, microphones + loopback).
  * out       : tableau de AudioDeviceInfo à remplir
  * max_count : taille du tableau

--- a/libcastor/src/AudioCapture.c
+++ b/libcastor/src/AudioCapture.c
@@ -554,9 +554,12 @@ CASTOR_CORE_API int audio_capture_init_source(AudioCaptureContext* ctx, AudioSou
             return audio_capture_init(ctx, NULL);
 
         case AUDIO_SOURCE_LOOPBACK_WINDOW:
-            /* Loopback par-process necessite ActivateAudioInterfaceAsync (C++ only).
-               Fallback sur loopback global en attendant. */
-            fprintf(stdout, "[AudioCapture] Loopback fenêtre → fallback global\n");
+            if (src->hwnd) {
+                int res = audio_capture_init_process_loopback(ctx, src->hwnd);
+                if (res == 0) return 0;
+                /* Fallback loopback global si le process loopback échoue (ex: Win < 19041) */
+                fprintf(stderr, "[AudioCapture] Process loopback échoué → fallback global\n");
+            }
             return audio_capture_init(ctx, NULL);
 
         case AUDIO_SOURCE_MICROPHONE:

--- a/libcastor/src/AudioProcessLoopback.cpp
+++ b/libcastor/src/AudioProcessLoopback.cpp
@@ -1,0 +1,256 @@
+/*
+ * AudioProcessLoopback.cpp
+ *
+ * Capture audio du process associe a un HWND via le Process Loopback API
+ * de Windows 10 2004+ (build 19041).
+ *
+ * Expose une seule fonction C : audio_capture_init_process_loopback().
+ */
+
+#define INITGUID
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <mmdeviceapi.h>
+#include <audioclient.h>
+#include <synchapi.h>
+#include <stdio.h>
+#include <string.h>
+
+extern "C" {
+#include "AudioCapture.h"
+}
+
+/* ------------------------------------------------------------------ *
+ *  Structures Windows Process Loopback (SDK 10.0.20348+)
+ * ------------------------------------------------------------------ */
+typedef enum {
+    AUDIOCLIENT_ACTIVATION_TYPE_DEFAULT          = 0,
+    AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK = 1,
+} AUDIOCLIENT_ACTIVATION_TYPE;
+
+typedef enum {
+    PROCESS_LOOPBACK_MODE_INCLUDE_TARGET_PROCESS_TREE = 0,
+    PROCESS_LOOPBACK_MODE_EXCLUDE_TARGET_PROCESS_TREE = 1,
+} PROCESS_LOOPBACK_MODE;
+
+typedef struct {
+    DWORD                TargetProcessId;
+    PROCESS_LOOPBACK_MODE ProcessLoopbackMode;
+} AUDIOCLIENT_PROCESS_LOOPBACK_PARAMS;
+
+typedef struct {
+    AUDIOCLIENT_ACTIVATION_TYPE         ActivationType;
+    AUDIOCLIENT_PROCESS_LOOPBACK_PARAMS ProcessLoopbackParams;
+} AUDIOCLIENT_ACTIVATION_PARAMS;
+
+/* VAD\Process_Loopback : device virtuel utilise par le Process Loopback API */
+static const wchar_t* VIRTUAL_AUDIO_DEVICE_PROCESS_LOOPBACK = L"VAD\\Process_Loopback";
+
+/* ------------------------------------------------------------------ *
+ *  IActivateAudioInterfaceCompletionHandler
+ * ------------------------------------------------------------------ */
+class ActivationHandler final : public IActivateAudioInterfaceCompletionHandler {
+public:
+    HANDLE       m_event;
+    IAudioClient* m_client  = nullptr;
+    HRESULT      m_result   = E_FAIL;
+    ULONG        m_refs     = 1;
+
+    ActivationHandler() {
+        m_event = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    }
+    ~ActivationHandler() {
+        CloseHandle(m_event);
+    }
+
+    /* IUnknown */
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppv) override {
+        if (riid == IID_IUnknown ||
+            riid == __uuidof(IActivateAudioInterfaceCompletionHandler)) {
+            *ppv = static_cast<IActivateAudioInterfaceCompletionHandler*>(this);
+            AddRef();
+            return S_OK;
+        }
+        *ppv = nullptr;
+        return E_NOINTERFACE;
+    }
+    ULONG STDMETHODCALLTYPE AddRef()  override { return ++m_refs; }
+    ULONG STDMETHODCALLTYPE Release() override {
+        ULONG r = --m_refs;
+        if (r == 0) delete this;
+        return r;
+    }
+
+    /* IActivateAudioInterfaceCompletionHandler */
+    HRESULT STDMETHODCALLTYPE ActivateCompleted(
+        IActivateAudioInterfaceAsyncOperation* op) override
+    {
+        HRESULT hr_activate = S_OK;
+        IUnknown* unk = nullptr;
+        op->GetActivateResult(&hr_activate, &unk);
+        m_result = hr_activate;
+        if (SUCCEEDED(hr_activate) && unk) {
+            unk->QueryInterface(__uuidof(IAudioClient),
+                                reinterpret_cast<void**>(&m_client));
+            unk->Release();
+        }
+        SetEvent(m_event);
+        return S_OK;
+    }
+
+    bool Wait(DWORD timeoutMs = 5000) const {
+        /* CoWaitForMultipleObjects pumpe les messages COM si le thread est STA
+         * (cas courant depuis le runtime .NET), ce qui evite un deadlock ou
+         * timeout lors de l'attente du callback ActivateCompleted. */
+        DWORD idx = 0;
+        HRESULT hr = CoWaitForMultipleObjects(COWAIT_DEFAULT, timeoutMs, 1, &m_event, &idx);
+        return SUCCEEDED(hr) && idx == 0;
+    }
+};
+
+/* ------------------------------------------------------------------ *
+ *  Contexte interne (meme layout qu'AudioCaptureInternal dans AudioCapture.c)
+ * ------------------------------------------------------------------ */
+typedef struct {
+    IMMDeviceEnumerator*  enumerator;  /* NULL pour process loopback */
+    IMMDevice*            device;      /* NULL pour process loopback */
+    IAudioClient*         client;
+    IAudioCaptureClient*  capture;
+    WAVEFORMATEX*         wave_fmt;
+    int                   sample_rate;
+    int                   channels;
+} AudioCaptureInternal;
+
+/* ------------------------------------------------------------------ *
+ *  audio_capture_init_process_loopback
+ *  hwnd : fenêtre dont on veut capturer l'audio.
+ *  Retourne 0 si succès, -1 si erreur (ou fallback si PID=0).
+ * ------------------------------------------------------------------ */
+extern "C"
+int audio_capture_init_process_loopback(AudioCaptureContext* ctx, void* hwnd)
+{
+    if (!ctx || !hwnd) return -1;
+
+    /* 1. Process ID depuis le HWND */
+    DWORD pid = 0;
+    GetWindowThreadProcessId(static_cast<HWND>(hwnd), &pid);
+    if (pid == 0) {
+        fprintf(stderr, "[ProcessLoopback] GetWindowThreadProcessId échoué\n");
+        return -1;
+    }
+
+    CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+
+    /* 2. AUDIOCLIENT_ACTIVATION_PARAMS → PROPVARIANT */
+    AUDIOCLIENT_ACTIVATION_PARAMS params = {};
+    params.ActivationType                               = AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK;
+    params.ProcessLoopbackParams.TargetProcessId        = pid;
+    params.ProcessLoopbackParams.ProcessLoopbackMode    = PROCESS_LOOPBACK_MODE_INCLUDE_TARGET_PROCESS_TREE;
+
+    PROPVARIANT pv = {};
+    pv.vt            = VT_BLOB;
+    pv.blob.cbSize   = sizeof(params);
+    pv.blob.pBlobData = reinterpret_cast<BYTE*>(&params);
+
+    /* 3. ActivateAudioInterfaceAsync */
+    auto* handler = new ActivationHandler();
+    IActivateAudioInterfaceAsyncOperation* asyncOp = nullptr;
+
+    HRESULT hr = ActivateAudioInterfaceAsync(
+        VIRTUAL_AUDIO_DEVICE_PROCESS_LOOPBACK,
+        __uuidof(IAudioClient),
+        &pv,
+        handler,
+        &asyncOp);
+
+    if (FAILED(hr)) {
+        fprintf(stderr, "[ProcessLoopback] ActivateAudioInterfaceAsync échoué: 0x%lx\n", hr);
+        handler->Release();
+        if (asyncOp) asyncOp->Release();
+        return -1;
+    }
+
+    /* 4. Attendre la complétion (max 5s) */
+    if (!handler->Wait()) {
+        fprintf(stderr, "[ProcessLoopback] Timeout activation (pid=%lu)\n", pid);
+        handler->Release();
+        if (asyncOp) asyncOp->Release();
+        return -1;
+    }
+
+    if (FAILED(handler->m_result) || !handler->m_client) {
+        fprintf(stderr, "[ProcessLoopback] Activation échouée: 0x%lx (pid=%lu)\n",
+                handler->m_result, pid);
+        handler->Release();
+        if (asyncOp) asyncOp->Release();
+        return -1;
+    }
+
+    IAudioClient* client = handler->m_client;
+    handler->m_client = nullptr;
+    handler->Release();
+    if (asyncOp) asyncOp->Release();
+
+    /* 5. Format du mix */
+    WAVEFORMATEX* wave_fmt = nullptr;
+    hr = client->GetMixFormat(&wave_fmt);
+    if (FAILED(hr)) {
+        fprintf(stderr, "[ProcessLoopback] GetMixFormat échoué: 0x%lx\n", hr);
+        client->Release();
+        return -1;
+    }
+
+    /* 6. Initialize en mode loopback */
+    hr = client->Initialize(
+        AUDCLNT_SHAREMODE_SHARED,
+        AUDCLNT_STREAMFLAGS_LOOPBACK,
+        10000000,   /* buffer 1s en unités 100ns */
+        0,
+        wave_fmt,
+        nullptr);
+    if (FAILED(hr)) {
+        fprintf(stderr, "[ProcessLoopback] Initialize échoué: 0x%lx\n", hr);
+        CoTaskMemFree(wave_fmt);
+        client->Release();
+        return -1;
+    }
+
+    /* 7. IAudioCaptureClient */
+    IAudioCaptureClient* capture = nullptr;
+    hr = client->GetService(__uuidof(IAudioCaptureClient),
+                            reinterpret_cast<void**>(&capture));
+    if (FAILED(hr)) {
+        fprintf(stderr, "[ProcessLoopback] GetService(IAudioCaptureClient) échoué: 0x%lx\n", hr);
+        CoTaskMemFree(wave_fmt);
+        client->Release();
+        return -1;
+    }
+
+    client->Start();
+
+    /* 8. Remplir le contexte (même layout qu'AudioCaptureInternal) */
+    AudioCaptureInternal* internal =
+        static_cast<AudioCaptureInternal*>(calloc(1, sizeof(AudioCaptureInternal)));
+    if (!internal) {
+        capture->Release();
+        CoTaskMemFree(wave_fmt);
+        client->Release();
+        return -1;
+    }
+
+    internal->enumerator  = nullptr;
+    internal->device      = nullptr;
+    internal->client      = client;
+    internal->capture     = capture;
+    internal->wave_fmt    = wave_fmt;
+    internal->sample_rate = static_cast<int>(wave_fmt->nSamplesPerSec);
+    internal->channels    = static_cast<int>(wave_fmt->nChannels);
+
+    ctx->internal    = internal;
+    ctx->sample_rate = internal->sample_rate;
+    ctx->channels    = internal->channels;
+
+    fprintf(stdout, "[ProcessLoopback] OK — pid=%lu, %d Hz, %d ch\n",
+            pid, ctx->sample_rate, ctx->channels);
+    return 0;
+}

--- a/libcastor/src/VideoEncode.c
+++ b/libcastor/src/VideoEncode.c
@@ -30,7 +30,12 @@ CASTOR_CORE_API int video_encoder_init_ex(VideoEncoder* enc, int width, int heig
     enc->ctx = avcodec_alloc_context3(codec);
     if (!enc->ctx) return -1;
 
-    const int gop = (cfg->gop_seconds > 0 ? cfg->gop_seconds : 2) * fps;
+    /* gop_seconds == 0 :
+     *   - zerolatency (preview) → fps/2 frames = 0,5 s à 30 fps : IDR fréquents,
+     *     permet à VLC de rejoindre le flux rapidement après une reconnexion.
+     *   - mode normal           → 2 s (défaut standard pour le broadcast). */
+    const int gop = cfg->gop_seconds > 0 ? cfg->gop_seconds * fps
+                  : (cfg->zerolatency   ? fps / 2 : 2 * fps);
 
     enc->ctx->width        = width;
     enc->ctx->height       = height;
@@ -55,10 +60,14 @@ CASTOR_CORE_API int video_encoder_init_ex(VideoEncoder* enc, int width, int heig
     /* --- Mode CBR ou CRF --- */
     if (cfg->cbr && cfg->video_bitrate_kbps > 0) {
         const int bps = cfg->video_bitrate_kbps * 1000;
-        enc->ctx->bit_rate  = bps;
+        enc->ctx->bit_rate    = bps;
         enc->ctx->rc_min_rate = bps;
         enc->ctx->rc_max_rate = bps;
-        enc->ctx->rc_buffer_size = bps * 2;  /* buffer = 2 * bitrate */
+        /* En mode zerolatency (preview live) : VBV = 0.5 s → réduit le buffer
+         * encoder côté RTMP sans casser le flux (x264 tolère ce VBV serré
+         * avec tune=zerolatency car nal-hrd est désactivé).
+         * En mode normal (broadcast) : VBV = 2 s → headroom réseau standard. */
+        enc->ctx->rc_buffer_size = cfg->zerolatency ? bps / 2 : bps * 2;
     }
 
     if (avcodec_open2(enc->ctx, codec, NULL) < 0) {


### PR DESCRIPTION
## Bug fixes & preview pipeline improvements

### Context
This branch consolidates several critical fixes around the preview pipeline, audio capture, and stability during scene switches. It addresses crashes, desync issues, and startup failures observed under real usage conditions.

---

### Changes

#### Crash & stability

**Crash on rapid camera switch** (`StudioView`, `ScenesView`, `RecorderService`)
- `PlayPreview` could be called simultaneously from multiple threads (VLC callback + UI + `Task.Run`), causing a double-dispose of the current `Media` object
- Added `_playLock` to serialize media swaps
- Added `_switchSemaphore` in `RecorderService.SwitchScene` to prevent two concurrent native `RecorderSwitchVideoSource` calls on the same pointer

**ObjectDisposedException on `_playCts`**
- `OnUnloaded` was disposing the `CancellationTokenSource` while in-flight VLC callbacks could still access it
- Callbacks now capture the local reference before the `await`, and catch `Exception` (not just `OperationCanceledException`) to silently absorb the `ObjectDisposedException`

---

#### Preview not starting without an active record or live stream

**Root cause**: the `EncounteredError` / `EndReached` retry callbacks only called `PlayPreview()` without restarting the recorder. If `StartPreview` had failed at startup (MediaMTX not ready yet), the preview would remain black indefinitely.

**Fix**: callbacks now call `EnsurePreviewRunning()` before `PlayPreview()` to restart the recorder if needed.

---

#### Preview latency reduction (Option 1)

**VLC** (`StudioView`, `ScenesView`)
- `--network-caching` and `--live-caching` reduced from 150 ms to 50 ms
- `--clock-jitter=0` and `--clock-synchro=0` to disable jitter compensation and PTS re-sync

**x264 encoder** (`VideoEncode.c`)
- Zerolatency mode (preview): VBV buffer reduced to `bps / 2` (0.5 s) instead of `bps * 2` (2 s)
- GOP formula: `gop_seconds = 0` triggers `fps / 2` frames in zerolatency mode, producing IDRs every ~0.5 s so VLC can rejoin the stream faster after a reconnect

---

#### Audio preview settings (`Settings > Audio`)

Two new persistent fields added to `ApplicationSettings`:

- **Preview volume slider** (0–100): controls VLC volume in real time from the settings panel
- **"Mute on record / live" checkbox**: automatically mutes the player when a recording or live stream starts, and restores the volume on stop

Applied to both **StudioView and ScenesView** (see below).

---

#### StudioView / ScenesView parity

All fixes above have been applied to `ScenesView`, which was still running the old implementation:
- Same low-latency VLC options
- `_isDisposed` + `_playLock` + `CancellationTokenSource`
- `PlayerVolume` / `MutePlayersOnRecord` loaded from `SettingsService` inside `ScenesViewModel`
- `RecorderService` now exposes 4 events (`RecordingStarted/Stopped`, `StreamingStarted/Stopped`) — `ScenesViewModel` subscribes to them to trigger auto-mute independently from `StudioViewModel`

---

#### Per-process audio capture (`AudioProcessLoopback.cpp`)

Implementation of the **Windows Process Loopback Capture API** to capture audio from a specific window without recording the entire system output:
- `AudioCapture.c`: the `AUDIO_SOURCE_LOOPBACK_WINDOW` case now calls `audio_capture_init_process_loopback` with a fallback to global loopback if the HWND is invalid
- `AudioProcessLoopback.cpp`: replaced `WaitForSingleObject` with `CoWaitForMultipleObjects` to prevent an STA deadlock in the COM callback thread

---

### Test plan
- [ ] Open the app and verify the preview starts without launching a recording
- [ ] Switch scenes rapidly (3-4 times in a row) — no crash
- [ ] Start a recording and verify the player is muted if the checkbox is enabled
- [ ] Stop the recording and verify the volume is restored
- [ ] Navigate to Scenes and verify the preview player respects the same volume setting and auto-mute
- [ ] Check preview latency: should be noticeably lower than before (target < 500 ms)