### PR TITLE
Feature/encoding options implementation

### DIFF
--- a/Castor.Native/CastorNative.cs
+++ b/Castor.Native/CastorNative.cs
@@ -314,6 +314,9 @@ namespace Castor.Native
 
         public CastorVideoCodec VideoCodec;
         public CastorAudioCodec AudioCodec;
+        public int OutputWidth;   // 0 = même que la capture
+        public int OutputHeight;  // 0 = même que la capture
+        public int QualityIndex;  // 0=haute 1=bonne 2=basse
     }
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]

--- a/Castor.Native/CastorNative.cs
+++ b/Castor.Native/CastorNative.cs
@@ -297,6 +297,9 @@ namespace Castor.Native
     public enum CastorOutputType  { File = 0, Rtmp = 1 }
     public enum CastorServiceType { Custom = 0, Twitch = 1, YouTube = 2 }
 
+    public enum CastorVideoCodec { H264 = 0, VP9 = 1 }
+    public enum CastorAudioCodec { AAC  = 0, Opus = 1 }
+
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
     public struct OutputConfig
     {
@@ -308,6 +311,9 @@ namespace Castor.Native
         public int VideoBitrateKbps;
         public int AudioBitrateKbps;
         public int GopSeconds;
+
+        public CastorVideoCodec VideoCodec;
+        public CastorAudioCodec AudioCodec;
     }
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]

--- a/CastorApplication/Models/Settings/ApplicationSettings.cs
+++ b/CastorApplication/Models/Settings/ApplicationSettings.cs
@@ -10,6 +10,9 @@ public sealed class ApplicationSettings
     public int SelectedOutputResolutionIndex { get; set; }
     public int SelectedFpsIndex { get; set; }
     public double VideoBitrate { get; set; } = 6000;
+    public double StreamingBitrate { get; set; } = 4000;
+
+    public int RecordingQualityIndex { get; set; } = 1; // 0=haute 1=bonne 2=basse
 
     public int SelectedSampleRateIndex { get; set; }
     public int SelectedChannelsIndex { get; set; }

--- a/CastorApplication/Services/RecorderService.cs
+++ b/CastorApplication/Services/RecorderService.cs
@@ -62,7 +62,10 @@ public sealed class RecorderService
     /// Démarre l'enregistrement de la scène vers outputPath.
     /// Retourne 0 si succès, code d'erreur négatif sinon.
     /// </summary>
-    public int Start(SceneItem scene, string outputPath, int fps = 30)
+    public int Start(SceneItem scene, string outputPath, int fps = 30,
+                     int videoBitrateKbps = 0,
+                     CastorVideoCodec videoCodec = CastorVideoCodec.H264,
+                     CastorAudioCodec audioCodec = CastorAudioCodec.AAC)
     {
         if (IsRecording) return -1;
 
@@ -90,8 +93,11 @@ public sealed class RecorderService
             AudioSrc = audioSrc,
             Output   = new OutputConfig
             {
-                Type        = CastorOutputType.File,
-                Destination = outputPath,
+                Type             = CastorOutputType.File,
+                Destination      = outputPath,
+                VideoBitrateKbps = videoBitrateKbps,
+                VideoCodec       = videoCodec,
+                AudioCodec       = audioCodec,
             }
         };
 
@@ -142,7 +148,8 @@ public sealed class RecorderService
     /// Démarre un stream RTMP vers la plateforme donnée.
     /// Retourne 0 si succès, code d'erreur négatif sinon.
     /// </summary>
-    public int StartStream(SceneItem scene, CastorServiceType service, string streamKeyOrUrl, int fps = 30)
+    public int StartStream(SceneItem scene, CastorServiceType service, string streamKeyOrUrl,
+                           int fps = 30, int videoBitrateKbps = 4000)
     {
         if (IsStreaming) return -1;
 
@@ -175,11 +182,13 @@ public sealed class RecorderService
             AudioSrc = audioSrc,
             Output   = new OutputConfig
             {
-                Type               = CastorOutputType.Rtmp,
-                Destination        = rtmpUrl,
-                VideoBitrateKbps   = 4000,
-                AudioBitrateKbps   = 128,
-                GopSeconds         = 2
+                Type             = CastorOutputType.Rtmp,
+                Destination      = rtmpUrl,
+                VideoBitrateKbps = videoBitrateKbps > 0 ? videoBitrateKbps : 4000,
+                AudioBitrateKbps = 128,
+                GopSeconds       = 2,
+                VideoCodec       = CastorVideoCodec.H264,
+                AudioCodec       = CastorAudioCodec.AAC,
             }
         };
 

--- a/CastorApplication/Services/RecorderService.cs
+++ b/CastorApplication/Services/RecorderService.cs
@@ -65,7 +65,9 @@ public sealed class RecorderService
     public int Start(SceneItem scene, string outputPath, int fps = 30,
                      int videoBitrateKbps = 0,
                      CastorVideoCodec videoCodec = CastorVideoCodec.H264,
-                     CastorAudioCodec audioCodec = CastorAudioCodec.AAC)
+                     CastorAudioCodec audioCodec = CastorAudioCodec.AAC,
+                     int outputWidth = 0, int outputHeight = 0,
+                     int qualityIndex = 1)
     {
         if (IsRecording) return -1;
 
@@ -98,6 +100,9 @@ public sealed class RecorderService
                 VideoBitrateKbps = videoBitrateKbps,
                 VideoCodec       = videoCodec,
                 AudioCodec       = audioCodec,
+                OutputWidth      = outputWidth,
+                OutputHeight     = outputHeight,
+                QualityIndex     = qualityIndex,
             }
         };
 

--- a/CastorApplication/ViewModels/Settings/Sections/StreamingSettingsViewModel.cs
+++ b/CastorApplication/ViewModels/Settings/Sections/StreamingSettingsViewModel.cs
@@ -17,19 +17,29 @@ public partial class StreamingSettingsViewModel : SettingsSectionViewModel
     [ObservableProperty]
     private int _selectedServerIndex;
 
+    [ObservableProperty]
+    private double _streamingBitrate = 4000;
+
+    public string StreamingBitrateDisplay => $"{(int)StreamingBitrate}";
+
+    partial void OnStreamingBitrateChanged(double value)
+        => OnPropertyChanged(nameof(StreamingBitrateDisplay));
+
     protected override void LoadCore(ApplicationSettings settings)
     {
         SelectedPlatformIndex = settings.SelectedPlatformIndex;
-        StreamKey = settings.StreamKey;
-        RtmpUrl = settings.RtmpUrl;
-        SelectedServerIndex = settings.SelectedServerIndex;
+        StreamKey             = settings.StreamKey;
+        RtmpUrl               = settings.RtmpUrl;
+        SelectedServerIndex   = settings.SelectedServerIndex;
+        StreamingBitrate      = settings.StreamingBitrate;
     }
 
     protected override void SaveCore(ApplicationSettings settings)
     {
         settings.SelectedPlatformIndex = SelectedPlatformIndex;
-        settings.StreamKey = StreamKey;
-        settings.RtmpUrl = RtmpUrl;
-        settings.SelectedServerIndex = SelectedServerIndex;
+        settings.StreamKey             = StreamKey;
+        settings.RtmpUrl               = RtmpUrl;
+        settings.SelectedServerIndex   = SelectedServerIndex;
+        settings.StreamingBitrate      = StreamingBitrate;
     }
 }

--- a/CastorApplication/ViewModels/Settings/Sections/VideoSettingsViewModel.cs
+++ b/CastorApplication/ViewModels/Settings/Sections/VideoSettingsViewModel.cs
@@ -16,27 +16,30 @@ public partial class VideoSettingsViewModel : SettingsSectionViewModel
 
     [ObservableProperty]
     private double _videoBitrate = 6000;
-    
+
+    [ObservableProperty]
+    private int _selectedQualityIndex = 1;
+
     public string VideoBitrateDisplay => $"{(int)VideoBitrate}";
 
     partial void OnVideoBitrateChanged(double value)
-    {
-        OnPropertyChanged(nameof(VideoBitrateDisplay));
-    }
+        => OnPropertyChanged(nameof(VideoBitrateDisplay));
 
     protected override void LoadCore(ApplicationSettings settings)
     {
-        SelectedBaseResolutionIndex = settings.SelectedBaseResolutionIndex;
+        SelectedBaseResolutionIndex   = settings.SelectedBaseResolutionIndex;
         SelectedOutputResolutionIndex = settings.SelectedOutputResolutionIndex;
-        SelectedFpsIndex = settings.SelectedFpsIndex;
-        VideoBitrate = settings.VideoBitrate;
+        SelectedFpsIndex              = settings.SelectedFpsIndex;
+        VideoBitrate                  = settings.VideoBitrate;
+        SelectedQualityIndex          = settings.RecordingQualityIndex;
     }
 
     protected override void SaveCore(ApplicationSettings settings)
     {
-        settings.SelectedBaseResolutionIndex = SelectedBaseResolutionIndex;
+        settings.SelectedBaseResolutionIndex   = SelectedBaseResolutionIndex;
         settings.SelectedOutputResolutionIndex = SelectedOutputResolutionIndex;
-        settings.SelectedFpsIndex = SelectedFpsIndex;
-        settings.VideoBitrate = VideoBitrate;
+        settings.SelectedFpsIndex              = SelectedFpsIndex;
+        settings.VideoBitrate                  = VideoBitrate;
+        settings.RecordingQualityIndex         = SelectedQualityIndex;
     }
 }

--- a/CastorApplication/ViewModels/StudioViewModel.cs
+++ b/CastorApplication/ViewModels/StudioViewModel.cs
@@ -236,6 +236,13 @@ public partial class StudioViewModel : ViewModelBase
         _ => 30,
     };
 
+    private static (int width, int height) OutputResolutionFromIndex(int index) => index switch
+    {
+        1 => (1280,  720),  // HD
+        2 => ( 854,  480),  // SD
+        _ => (1920, 1080),  // Full HD (défaut)
+    };
+
     private static (string extension, CastorVideoCodec vcodec, CastorAudioCodec acodec)
         FormatFromIndex(int index) => index switch
     {
@@ -354,7 +361,7 @@ public partial class StudioViewModel : ViewModelBase
 
         var streamSettings = _settingsService.Load();
         int streamFps     = FpsFromIndex(streamSettings.SelectedFpsIndex);
-        int streamBitrate = (int)streamSettings.VideoBitrate;
+        int streamBitrate = (int)streamSettings.StreamingBitrate;
 
         // streaming_service_get_url peut faire un appel HTTPS (Twitch) → thread BG
         int result = await Task.Run(() =>
@@ -409,14 +416,17 @@ public partial class StudioViewModel : ViewModelBase
         }
 
         var settings = _settingsService.Load();
-        var (ext, vcodec, acodec) = FormatFromIndex(settings.SelectedOutputFormatIndex);
-        int fps     = FpsFromIndex(settings.SelectedFpsIndex);
-        int bitrate = (int)settings.VideoBitrate;
+        var (ext, vcodec, acodec)   = FormatFromIndex(settings.SelectedOutputFormatIndex);
+        int fps                     = FpsFromIndex(settings.SelectedFpsIndex);
+        int bitrate                 = (int)settings.VideoBitrate;
+        var (outW, outH)            = OutputResolutionFromIndex(settings.SelectedOutputResolutionIndex);
+        int quality                 = settings.RecordingQualityIndex;
 
         var path = await PickOutputFileAsync(ext, vcodec, acodec);
         if (path == null) return; // annulé par l'utilisateur
 
-        int result = RecorderService.Instance.Start(scene, path, fps, bitrate, vcodec, acodec);
+        int result = RecorderService.Instance.Start(scene, path, fps, bitrate, vcodec, acodec,
+                                                    outW, outH, quality);
         if (result == 0)
         {
             IsRecording = true;

--- a/CastorApplication/ViewModels/StudioViewModel.cs
+++ b/CastorApplication/ViewModels/StudioViewModel.cs
@@ -208,10 +208,12 @@ public partial class StudioViewModel : ViewModelBase
     // ── Constructor ──
 
     private readonly IProviderStore _providerStore;
+    private readonly SettingsService _settingsService;
 
     public StudioViewModel(IProviderStore providerStore, SettingsService settingsService)
     {
-        _providerStore = providerStore;
+        _providerStore   = providerStore;
+        _settingsService = settingsService;
 
         // Charge les valeurs de lecture depuis les paramètres persistés
         var settings = settingsService.Load();
@@ -224,6 +226,23 @@ public partial class StudioViewModel : ViewModelBase
         Layout = factory.CreateLayout();
         factory.InitLayout(Layout);
     }
+
+    // ── Helpers settings → valeurs encoder ───────────────────────────────────
+
+    private static int FpsFromIndex(int index) => index switch
+    {
+        0 => 60,
+        2 => 25,
+        _ => 30,
+    };
+
+    private static (string extension, CastorVideoCodec vcodec, CastorAudioCodec acodec)
+        FormatFromIndex(int index) => index switch
+    {
+        1 => (".mkv",  CastorVideoCodec.H264, CastorAudioCodec.AAC),
+        2 => (".webm", CastorVideoCodec.VP9,  CastorAudioCodec.Opus),
+        _ => (".mp4",  CastorVideoCodec.H264, CastorAudioCodec.AAC),
+    };
 
     /// <summary>
     /// Démarre le preview si une scène vidéo est active et que le preview ne tourne pas déjà.
@@ -333,8 +352,13 @@ public partial class StudioViewModel : ViewModelBase
                 System.Diagnostics.Debug.WriteLine($"[Preview] StartPreview (StartStreaming) retourné : {r}");
             });
 
+        var streamSettings = _settingsService.Load();
+        int streamFps     = FpsFromIndex(streamSettings.SelectedFpsIndex);
+        int streamBitrate = (int)streamSettings.VideoBitrate;
+
         // streaming_service_get_url peut faire un appel HTTPS (Twitch) → thread BG
-        int result = await Task.Run(() => RecorderService.Instance.StartStream(scene, service, keyOrUrl));
+        int result = await Task.Run(() =>
+            RecorderService.Instance.StartStream(scene, service, keyOrUrl, streamFps, streamBitrate));
 
         if (result == 0)
         {
@@ -373,10 +397,15 @@ public partial class StudioViewModel : ViewModelBase
             return;
         }
 
-        var path = await PickOutputFileAsync();
+        var settings = _settingsService.Load();
+        var (ext, vcodec, acodec) = FormatFromIndex(settings.SelectedOutputFormatIndex);
+        int fps     = FpsFromIndex(settings.SelectedFpsIndex);
+        int bitrate = (int)settings.VideoBitrate;
+
+        var path = await PickOutputFileAsync(ext, vcodec, acodec);
         if (path == null) return; // annulé par l'utilisateur
 
-        int result = RecorderService.Instance.Start(scene, path);
+        int result = RecorderService.Instance.Start(scene, path, fps, bitrate, vcodec, acodec);
         if (result == 0)
         {
             IsRecording = true;
@@ -401,7 +430,8 @@ public partial class StudioViewModel : ViewModelBase
         RestoreAutoMute();
     }
 
-    private static async Task<string?> PickOutputFileAsync()
+    private static async Task<string?> PickOutputFileAsync(
+        string extension, CastorVideoCodec vcodec, CastorAudioCodec acodec)
     {
         if (Application.Current?.ApplicationLifetime
             is not IClassicDesktopStyleApplicationLifetime desktop)
@@ -410,18 +440,29 @@ public partial class StudioViewModel : ViewModelBase
         var topLevel = TopLevel.GetTopLevel(desktop.MainWindow);
         if (topLevel == null) return null;
 
+        string label = (vcodec, acodec) switch
+        {
+            (CastorVideoCodec.VP9,  CastorAudioCodec.Opus) => "WebM (VP9 + Opus)",
+            (CastorVideoCodec.H264, _) when extension == ".mkv" => "MKV (H.264 + AAC)",
+            _ => "MP4 (H.264 + AAC)",
+        };
+
         var file = await topLevel.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
         {
             Title             = "Enregistrer la vidéo sous...",
-            SuggestedFileName = $"Castor_{DateTime.Now:yyyyMMdd_HHmmss}",
+            SuggestedFileName = $"Castor_{DateTime.Now:yyyyMMdd_HHmmss}{extension}",
             FileTypeChoices   =
             [
-                new FilePickerFileType("MP4 (H.264 + AAC)") { Patterns = ["*.mp4"] },
-                new FilePickerFileType("MKV (H.264 + AAC)") { Patterns = ["*.mkv"] },
+                new FilePickerFileType(label) { Patterns = [$"*{extension}"] },
             ]
         });
 
-        return file?.Path.LocalPath;
+        // Garantir que le chemin retourné a la bonne extension
+        var path = file?.Path.LocalPath;
+        if (path != null && !path.EndsWith(extension, StringComparison.OrdinalIgnoreCase))
+            path += extension;
+
+        return path;
     }
 
     // ── Source management ──

--- a/CastorApplication/ViewModels/StudioViewModel.cs
+++ b/CastorApplication/ViewModels/StudioViewModel.cs
@@ -368,10 +368,21 @@ public partial class StudioViewModel : ViewModelBase
         else
             StreamError = result switch
             {
-                -2 => "Aucune source vidéo dans la scène.",
-                -3 => "Impossible de créer le recorder natif.",
-                -4 => "Impossible de construire l'URL RTMP (clé invalide ?).",
-                _  => $"Erreur streaming (code {result})."
+                -2  => "Aucune source vidéo dans la scène sélectionnée.",
+                -3  => "Impossible de créer le recorder natif.",
+                -4  => "Impossible de construire l'URL RTMP (clé invalide ?).",
+                -10 => "Impossible d'ouvrir la capture vidéo.",
+                -11 => "Dimensions vidéo invalides (0×0).",
+                -12 => "Impossible d'ouvrir la capture audio.",
+                -20 => "Codec vidéo introuvable (H.264 absent de l'avcodec.dll).",
+                -21 => "Impossible d'initialiser l'encodeur vidéo.",
+                -22 => "Impossible d'initialiser le convertisseur de pixels.",
+                -25 => "Codec audio introuvable (AAC absent de l'avcodec.dll).",
+                -26 => "Impossible d'initialiser l'encodeur audio.",
+                -27 => "Erreur d'allocation du buffer audio.",
+                -30 => "Impossible d'ouvrir la connexion RTMP.",
+                -31 => "Erreur d'initialisation du muxer RTMP.",
+                _   => $"Erreur streaming (code {result})."
             };
     }
 
@@ -415,9 +426,20 @@ public partial class StudioViewModel : ViewModelBase
         {
             RecordError = result switch
             {
-                -2 => "Aucune source vidéo dans la scène.",
-                -3 => "Impossible de créer le recorder natif.",
-                _  => $"Erreur recorder (code {result})."
+                -2  => "Aucune source vidéo dans la scène.",
+                -3  => "Impossible de créer le recorder natif.",
+                -10 => "Impossible d'ouvrir la capture vidéo.",
+                -11 => "Dimensions vidéo invalides (0×0).",
+                -12 => "Impossible d'ouvrir la capture audio.",
+                -20 => "Codec vidéo introuvable — recompilez avec support VP9/H.264.",
+                -21 => "Impossible d'initialiser l'encodeur vidéo.",
+                -22 => "Impossible d'initialiser le convertisseur de pixels.",
+                -25 => "Codec audio introuvable — recompilez avec support Opus/AAC.",
+                -26 => "Impossible d'initialiser l'encodeur audio.",
+                -27 => "Erreur d'allocation du buffer audio.",
+                -30 => "Impossible de créer le fichier de sortie (chemin invalide ou disque plein ?).",
+                -31 => "Erreur d'initialisation du muxer (codec incompatible avec le conteneur ?).",
+                _   => $"Erreur inconnue (code {result})."
             };
         }
     }

--- a/CastorApplication/Views/Settings/Sections/StreamingSettingsView.axaml
+++ b/CastorApplication/Views/Settings/Sections/StreamingSettingsView.axaml
@@ -70,6 +70,33 @@
             <Grid ColumnDefinitions="180,*">
 
                 <TextBlock Grid.Column="0"
+                           Text="Débit stream (kbps)"
+                           Classes="setting-label"/>
+
+                <StackPanel Grid.Column="1"
+                            Orientation="Horizontal"
+                            Spacing="10"
+                            MaxWidth="320">
+
+                    <Slider Minimum="500"
+                            Maximum="10000"
+                            Width="220"
+                            VerticalAlignment="Center"
+                            Value="{Binding StreamingBitrate}"/>
+
+                    <TextBlock Width="50"
+                               VerticalAlignment="Center"
+                               FontSize="12"
+                               Foreground="{DynamicResource AppFg4}"
+                               Text="{Binding StreamingBitrateDisplay}"/>
+
+                </StackPanel>
+
+            </Grid>
+
+            <Grid ColumnDefinitions="180,*">
+
+                <TextBlock Grid.Column="0"
                            Text="Serveur"
                            Classes="setting-label"/>
 

--- a/CastorApplication/Views/Settings/Sections/VideoSettingsView.axaml
+++ b/CastorApplication/Views/Settings/Sections/VideoSettingsView.axaml
@@ -1,4 +1,4 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:CastorApplication.ViewModels.Settings.Sections"
              x:Class="CastorApplication.Views.Settings.Sections.VideoSettingsView"
@@ -72,7 +72,26 @@
             <Grid ColumnDefinitions="180,*">
 
                 <TextBlock Grid.Column="0"
-                           Text="D�bit vid�o (kbps)"
+                           Text="Qualité (CRF)"
+                           Classes="setting-label"/>
+
+                <ComboBox Grid.Column="1"
+                          MaxWidth="260"
+                          HorizontalAlignment="Left"
+                          SelectedIndex="{Binding SelectedQualityIndex}">
+
+                    <ComboBoxItem Content="Haute"/>
+                    <ComboBoxItem Content="Bonne"/>
+                    <ComboBoxItem Content="Basse"/>
+
+                </ComboBox>
+
+            </Grid>
+
+            <Grid ColumnDefinitions="180,*">
+
+                <TextBlock Grid.Column="0"
+                           Text="Débit enregistrement (kbps)"
                            Classes="setting-label"/>
 
                 <StackPanel Grid.Column="1"

--- a/build-native.ps1
+++ b/build-native.ps1
@@ -2,7 +2,8 @@
 
 param(
     [string]$Preset = "x64-debug",
-    [switch]$Reconfigure   # Supprime le build dir existant pour forcer une reconfiguration cmake
+    [switch]$Reconfigure,  # Supprime le build dir existant pour forcer une reconfiguration cmake
+    [switch]$CleanVcpkg    # Supprime aussi vcpkg_installed (force la reinstallation des paquets)
 )
 
 $ErrorActionPreference = "Stop"
@@ -48,6 +49,19 @@ $ninjaFile = Join-Path $buildDir "build.ninja"
 if ($Reconfigure -and (Test-Path $buildDir)) {
     Write-Host "[build-native] -Reconfigure : suppression de $buildDir ..."
     Remove-Item -Recurse -Force $buildDir
+}
+
+# -CleanVcpkg : supprime vcpkg_installed pour forcer la reinstallation des paquets
+# (necessaire quand vcpkg.json change : ajout/suppression de features).
+$vcpkgInstalled = "libcastor/vcpkg_installed"
+if ($CleanVcpkg -and (Test-Path $vcpkgInstalled)) {
+    Write-Host "[build-native] -CleanVcpkg : suppression de $vcpkgInstalled ..."
+    Remove-Item -Recurse -Force $vcpkgInstalled
+    # Force aussi la reconfiguration cmake (sinon le build.ninja pointe sur des paths invalides)
+    if (Test-Path $buildDir) {
+        Write-Host "[build-native] -CleanVcpkg : suppression de $buildDir (coherence) ..."
+        Remove-Item -Recurse -Force $buildDir
+    }
 }
 
 if (!(Test-Path $ninjaFile)) {

--- a/build-native.ps1
+++ b/build-native.ps1
@@ -1,7 +1,8 @@
 # build-native.ps1
 
 param(
-    [string]$Preset = "x64-debug"
+    [string]$Preset = "x64-debug",
+    [switch]$Reconfigure   # Supprime le build dir existant pour forcer une reconfiguration cmake
 )
 
 $ErrorActionPreference = "Stop"
@@ -43,6 +44,11 @@ foreach ($line in $envVars) {
 # configuration
 $buildDir = "out/build/$Preset"
 $ninjaFile = Join-Path $buildDir "build.ninja"
+
+if ($Reconfigure -and (Test-Path $buildDir)) {
+    Write-Host "[build-native] -Reconfigure : suppression de $buildDir ..."
+    Remove-Item -Recurse -Force $buildDir
+}
 
 if (!(Test-Path $ninjaFile)) {
     Write-Host "[build-native] Configuration cmake --preset $Preset ..."

--- a/libcastor/include/AudioEncode.h
+++ b/libcastor/include/AudioEncode.h
@@ -13,18 +13,28 @@ extern "C" {
 #endif
 
 /* ================================================================== *
+ *  CastorAudioCodec — codec audio selectionnable
+ * ================================================================== */
+typedef enum {
+    CASTOR_ACODEC_AAC  = 0,  /* AAC — MP4 / MKV / RTMP */
+    CASTOR_ACODEC_OPUS = 1,  /* libopus — WebM          */
+} CastorAudioCodec;
+
+/* ================================================================== *
  *  AudioEncoderConfig — parametres d'encodage audio.
  *
  *  audio_bitrate_kbps : 0 = defaut (128 kb/s)
  * ================================================================== */
 typedef struct {
-    int audio_bitrate_kbps;
+    int              audio_bitrate_kbps;
+    CastorAudioCodec audio_codec;
 } AudioEncoderConfig;
 
 static inline AudioEncoderConfig audio_encoder_config_default(void)
 {
     AudioEncoderConfig c;
     c.audio_bitrate_kbps = 128;
+    c.audio_codec        = CASTOR_ACODEC_AAC;
     return c;
 }
 

--- a/libcastor/include/Recorder.h
+++ b/libcastor/include/Recorder.h
@@ -34,12 +34,15 @@ typedef enum {
 
 typedef struct {
     CastorOutputType type;
-    char             destination[512];    /* chemin fichier ou rtmp:// URL */
-    int              video_bitrate_kbps;  /* 0 = defaut (4000 en RTMP)    */
-    int              audio_bitrate_kbps;  /* 0 = defaut (128 en RTMP)     */
-    int              gop_seconds;         /* 0 = defaut (2s)              */
-    CastorVideoCodec video_codec;         /* codec video (H264 par defaut)*/
-    CastorAudioCodec audio_codec;         /* codec audio (AAC par defaut) */
+    char             destination[512];    /* chemin fichier ou rtmp:// URL  */
+    int              video_bitrate_kbps;  /* 0 = defaut (4000 en RTMP)      */
+    int              audio_bitrate_kbps;  /* 0 = defaut (128 en RTMP)       */
+    int              gop_seconds;         /* 0 = defaut (2s)                */
+    CastorVideoCodec video_codec;         /* codec video (H264 par defaut)  */
+    CastorAudioCodec audio_codec;         /* codec audio (AAC par defaut)   */
+    int              output_width;        /* 0 = meme que la capture        */
+    int              output_height;       /* 0 = meme que la capture        */
+    int              quality_index;       /* 0=haute 1=bonne 2=basse        */
 } OutputConfig;
 
 /* ================================================================== *

--- a/libcastor/include/Recorder.h
+++ b/libcastor/include/Recorder.h
@@ -2,6 +2,8 @@
 #include "castor_api.h"
 #include "VideoCapture.h"
 #include "AudioCapture.h"
+#include "VideoEncode.h"
+#include "AudioEncode.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,12 +14,13 @@ extern "C" {
 /* ================================================================== *
  *  OutputConfig — destination et parametres d'encodage pour un stream.
  *
- *  type = CASTOR_OUTPUT_FILE  ->  destination = chemin fichier (.mp4, ...)
+ *  type = CASTOR_OUTPUT_FILE  ->  destination = chemin fichier (.mp4/.mkv/.webm)
  *  type = CASTOR_OUTPUT_RTMP  ->  destination = URL RTMP/RTMPS
  *
- *  Les champs video_bitrate_kbps, audio_bitrate_kbps, gop_seconds
- *  ne sont utilises qu'en mode RTMP (ignores en mode fichier).
- *  Mettre a 0 pour appliquer les valeurs par defaut.
+ *  video_bitrate_kbps / audio_bitrate_kbps : 0 = qualite par defaut (CRF/CQ).
+ *  Si > 0, encodage CBR — recommande pour RTMP, optionnel pour fichier.
+ *  gop_seconds : 0 = defaut (2s).
+ *  video_codec / audio_codec : RTMP force toujours H264+AAC.
  *
  *  Terrain pour sorties multiples (record + stream simultanement) :
  *  StreamConfig passera de "OutputConfig output" a
@@ -31,10 +34,12 @@ typedef enum {
 
 typedef struct {
     CastorOutputType type;
-    char             destination[512]; /* chemin fichier ou rtmp:// URL */
-    int              video_bitrate_kbps;  /* 0 = defaut (4000 en RTMP)  */
-    int              audio_bitrate_kbps;  /* 0 = defaut (128 en RTMP)   */
-    int              gop_seconds;         /* 0 = defaut (2s)            */
+    char             destination[512];    /* chemin fichier ou rtmp:// URL */
+    int              video_bitrate_kbps;  /* 0 = defaut (4000 en RTMP)    */
+    int              audio_bitrate_kbps;  /* 0 = defaut (128 en RTMP)     */
+    int              gop_seconds;         /* 0 = defaut (2s)              */
+    CastorVideoCodec video_codec;         /* codec video (H264 par defaut)*/
+    CastorAudioCodec audio_codec;         /* codec audio (AAC par defaut) */
 } OutputConfig;
 
 /* ================================================================== *

--- a/libcastor/include/VideoEncode.h
+++ b/libcastor/include/VideoEncode.h
@@ -12,6 +12,14 @@ extern "C" {
 #endif
 
 /* ================================================================== *
+ *  CastorVideoCodec — codec video selectionnable
+ * ================================================================== */
+typedef enum {
+    CASTOR_VCODEC_H264 = 0,  /* libx264 — MP4 / MKV / RTMP */
+    CASTOR_VCODEC_VP9  = 1,  /* libvpx-vp9 — WebM          */
+} CastorVideoCodec;
+
+/* ================================================================== *
  *  VideoEncoderConfig — parametres d'encodage video.
  *
  *  Deux modes :
@@ -19,33 +27,36 @@ extern "C" {
  *    - CBR  (cbr=1) : debit constant, latence maitrisee.  Ideal pour RTMP.
  *
  *  Helpers fournis :
- *    video_encoder_config_default() -> CRF, preset veryfast, GOP 2s
- *    video_encoder_config_rtmp(bitrate, gop) -> CBR, zerolatency
+ *    video_encoder_config_default() -> H264 CRF, preset veryfast, GOP 2s
+ *    video_encoder_config_rtmp(bitrate, gop) -> H264 CBR, zerolatency
  * ================================================================== */
 typedef struct {
-    int cbr;                  /* 0 = CRF (qualite), 1 = CBR (debit constant) */
-    int video_bitrate_kbps;   /* debit video en kb/s     — utilise si cbr=1  */
-    int gop_seconds;          /* intervalle keyframe (s) — 0 = defaut (2s)   */
-    int zerolatency;          /* 1 = tune zerolatency    — recommande RTMP   */
+    int              cbr;                /* 0 = CRF (qualite), 1 = CBR (debit constant) */
+    int              video_bitrate_kbps; /* debit video en kb/s     — utilise si cbr=1  */
+    int              gop_seconds;        /* intervalle keyframe (s) — 0 = defaut (2s)   */
+    int              zerolatency;        /* 1 = tune zerolatency    — recommande RTMP   */
+    CastorVideoCodec video_codec;        /* codec selectionne                           */
 } VideoEncoderConfig;
 
 static inline VideoEncoderConfig video_encoder_config_default(void)
 {
     VideoEncoderConfig c;
-    c.cbr               = 0;
+    c.cbr                = 0;
     c.video_bitrate_kbps = 0;
-    c.gop_seconds       = 2;
-    c.zerolatency       = 0;
+    c.gop_seconds        = 2;
+    c.zerolatency        = 0;
+    c.video_codec        = CASTOR_VCODEC_H264;
     return c;
 }
 
 static inline VideoEncoderConfig video_encoder_config_rtmp(int bitrate_kbps, int gop_seconds)
 {
     VideoEncoderConfig c;
-    c.cbr               = 1;
+    c.cbr                = 1;
     c.video_bitrate_kbps = bitrate_kbps > 0 ? bitrate_kbps : 4000;
-    c.gop_seconds       = gop_seconds  > 0 ? gop_seconds  : 2;
-    c.zerolatency       = 1;
+    c.gop_seconds        = gop_seconds  > 0 ? gop_seconds  : 2;
+    c.zerolatency        = 1;
+    c.video_codec        = CASTOR_VCODEC_H264;
     return c;
 }
 

--- a/libcastor/include/VideoEncode.h
+++ b/libcastor/include/VideoEncode.h
@@ -43,18 +43,15 @@ typedef struct {
 
 static inline VideoEncoderConfig video_encoder_config_default(void)
 {
-    VideoEncoderConfig c;
-    c.cbr                = 0;
-    c.video_bitrate_kbps = 0;
-    c.gop_seconds        = 2;
-    c.zerolatency        = 0;
-    c.video_codec        = CASTOR_VCODEC_H264;
+    VideoEncoderConfig c = {0};  /* zero-init : tout champ futur sera safe */
+    c.gop_seconds = 2;
+    c.video_codec = CASTOR_VCODEC_H264;
     return c;
 }
 
 static inline VideoEncoderConfig video_encoder_config_rtmp(int bitrate_kbps, int gop_seconds)
 {
-    VideoEncoderConfig c;
+    VideoEncoderConfig c = {0};  /* zero-init : tout champ futur sera safe */
     c.cbr                = 1;
     c.video_bitrate_kbps = bitrate_kbps > 0 ? bitrate_kbps : 4000;
     c.gop_seconds        = gop_seconds  > 0 ? gop_seconds  : 2;
@@ -77,8 +74,6 @@ typedef struct {
                                          * champ pour calculer frame->pts correctement
                                          * via av_rescale_q, quel que soit le codec. */
     struct SwsContext* sws_ctx;         /* BGRA -> YUV420P */
-    int64_t            first_pts;
-    int                first_pts_set;
 } VideoEncoder;
 
 /*

--- a/libcastor/include/VideoEncode.h
+++ b/libcastor/include/VideoEncode.h
@@ -36,6 +36,9 @@ typedef struct {
     int              gop_seconds;        /* intervalle keyframe (s) — 0 = defaut (2s)   */
     int              zerolatency;        /* 1 = tune zerolatency    — recommande RTMP   */
     CastorVideoCodec video_codec;        /* codec selectionne                           */
+    int              src_width;          /* largeur capture source  — 0 = meme que out  */
+    int              src_height;         /* hauteur capture source  — 0 = meme que out  */
+    int              crf;                /* valeur CRF explicite    — 0 = defaut codec   */
 } VideoEncoderConfig;
 
 static inline VideoEncoderConfig video_encoder_config_default(void)

--- a/libcastor/include/VideoEncode.h
+++ b/libcastor/include/VideoEncode.h
@@ -68,7 +68,12 @@ typedef struct {
     AVFrame*           frame;
     AVPacket*          pkt;
     int                frame_index;
-    struct SwsContext* sws_ctx;     /* BGRA -> YUV420P */
+    int                fps;             /* fps cible — sauvegarde AVANT avcodec_open2.
+                                         * Certains encodeurs (libvpx-vp9) modifient
+                                         * ctx->time_base apres open ; on utilise ce
+                                         * champ pour calculer frame->pts correctement
+                                         * via av_rescale_q, quel que soit le codec. */
+    struct SwsContext* sws_ctx;         /* BGRA -> YUV420P */
     int64_t            first_pts;
     int                first_pts_set;
 } VideoEncoder;

--- a/libcastor/src/AudioEncode.c
+++ b/libcastor/src/AudioEncode.c
@@ -14,18 +14,22 @@ CASTOR_CORE_API int audio_encoder_init_ex(AudioEncoder* enc, int sample_rate,
     AudioEncoderConfig defaults = audio_encoder_config_default();
     if (!cfg) cfg = &defaults;
 
+    /* Codes de retour :
+     *  -25 : codec introuvable (libopus / AAC absent de l'avcodec.dll)
+     *  -26 : avcodec_open2 a echoue
+     *  -27 : av_audio_fifo_alloc a echoue */
     const AVCodec* codec = NULL;
     if (cfg->audio_codec == CASTOR_ACODEC_OPUS) {
         codec = avcodec_find_encoder_by_name("libopus");
         if (!codec) {
-            fprintf(stderr, "[AudioEncoder] libopus introuvable\n");
-            return -1;
+            fprintf(stderr, "[AudioEncoder] libopus introuvable — recompilez FFmpeg avec --enable-libopus\n");
+            return -25;
         }
     } else {
         codec = avcodec_find_encoder(AV_CODEC_ID_AAC);
         if (!codec) {
             fprintf(stderr, "[AudioEncoder] codec AAC introuvable\n");
-            return -1;
+            return -25;
         }
     }
     fprintf(stderr, "[AudioEncoder] codec : %s\n", codec->name);
@@ -60,7 +64,7 @@ CASTOR_CORE_API int audio_encoder_init_ex(AudioEncoder* enc, int sample_rate,
     if (avcodec_open2(enc->ctx, codec, NULL) < 0) {
         fprintf(stderr, "[AudioEncoder] avcodec_open2 failed\n");
         avcodec_free_context(&enc->ctx);
-        return -1;
+        return -26;
     }
 
     enc->frame = av_frame_alloc();
@@ -80,7 +84,7 @@ CASTOR_CORE_API int audio_encoder_init_ex(AudioEncoder* enc, int sample_rate,
         avcodec_free_context(&enc->ctx);
         av_frame_free(&enc->frame);
         av_packet_free(&enc->pkt);
-        return -1;
+        return -27;
     }
 
     return 0;

--- a/libcastor/src/AudioEncode.c
+++ b/libcastor/src/AudioEncode.c
@@ -14,21 +14,45 @@ CASTOR_CORE_API int audio_encoder_init_ex(AudioEncoder* enc, int sample_rate,
     AudioEncoderConfig defaults = audio_encoder_config_default();
     if (!cfg) cfg = &defaults;
 
-    const AVCodec* codec = avcodec_find_encoder(AV_CODEC_ID_AAC);
-    if (!codec) {
-        fprintf(stderr, "[AudioEncoder] codec AAC introuvable\n");
-        return -1;
+    const AVCodec* codec = NULL;
+    if (cfg->audio_codec == CASTOR_ACODEC_OPUS) {
+        codec = avcodec_find_encoder_by_name("libopus");
+        if (!codec) {
+            fprintf(stderr, "[AudioEncoder] libopus introuvable\n");
+            return -1;
+        }
+    } else {
+        codec = avcodec_find_encoder(AV_CODEC_ID_AAC);
+        if (!codec) {
+            fprintf(stderr, "[AudioEncoder] codec AAC introuvable\n");
+            return -1;
+        }
     }
+    fprintf(stderr, "[AudioEncoder] codec : %s\n", codec->name);
 
     enc->ctx = avcodec_alloc_context3(codec);
     if (!enc->ctx) return -1;
 
     enc->ctx->sample_rate = sample_rate;
-    enc->ctx->sample_fmt  = AV_SAMPLE_FMT_FLTP;
     enc->ctx->bit_rate    = (cfg->audio_bitrate_kbps > 0
                              ? cfg->audio_bitrate_kbps
                              : 128) * 1000;
     av_channel_layout_default(&enc->ctx->ch_layout, 2);
+
+    /* Choisir le meilleur sample_fmt supporte par ce codec.
+     * On prefere FLTP (planar float) ; certains codecs (ex: libopus) peuvent
+     * preferer FLT (interleave) ou S16. */
+    enum AVSampleFormat preferred = AV_SAMPLE_FMT_FLTP;
+    if (codec->sample_fmts) {
+        int fltp_ok = 0;
+        for (const enum AVSampleFormat* f = codec->sample_fmts;
+             *f != AV_SAMPLE_FMT_NONE; f++) {
+            if (*f == preferred) { fltp_ok = 1; break; }
+        }
+        if (!fltp_ok)
+            preferred = codec->sample_fmts[0];
+    }
+    enc->ctx->sample_fmt = preferred;
 
     if (avcodec_open2(enc->ctx, codec, NULL) < 0) {
         fprintf(stderr, "[AudioEncoder] avcodec_open2 failed\n");
@@ -48,7 +72,7 @@ CASTOR_CORE_API int audio_encoder_init_ex(AudioEncoder* enc, int sample_rate,
     enc->swr          = NULL;
 
     enc->fifo = av_audio_fifo_alloc(
-        AV_SAMPLE_FMT_FLTP, 2, enc->ctx->frame_size * 4);
+        enc->ctx->sample_fmt, 2, enc->ctx->frame_size * 4);
     if (!enc->fifo) {
         avcodec_free_context(&enc->ctx);
         av_frame_free(&enc->frame);

--- a/libcastor/src/AudioEncode.c
+++ b/libcastor/src/AudioEncode.c
@@ -33,7 +33,10 @@ CASTOR_CORE_API int audio_encoder_init_ex(AudioEncoder* enc, int sample_rate,
     enc->ctx = avcodec_alloc_context3(codec);
     if (!enc->ctx) return -1;
 
-    enc->ctx->sample_rate = sample_rate;
+    /* libopus n'accepte que 8000/12000/16000/24000/48000 Hz.
+     * Si la source WASAPI est a 44100 Hz, avcodec_open2 echouerait.
+     * On force 48000 Hz ; swr_convert resamplera a la volee si besoin. */
+    enc->ctx->sample_rate = (cfg->audio_codec == CASTOR_ACODEC_OPUS) ? 48000 : sample_rate;
     enc->ctx->bit_rate    = (cfg->audio_bitrate_kbps > 0
                              ? cfg->audio_bitrate_kbps
                              : 128) * 1000;
@@ -63,7 +66,7 @@ CASTOR_CORE_API int audio_encoder_init_ex(AudioEncoder* enc, int sample_rate,
     enc->frame = av_frame_alloc();
     enc->frame->nb_samples  = enc->ctx->frame_size;
     enc->frame->format      = enc->ctx->sample_fmt;
-    enc->frame->sample_rate = sample_rate;
+    enc->frame->sample_rate = enc->ctx->sample_rate;
     av_channel_layout_copy(&enc->frame->ch_layout, &enc->ctx->ch_layout);
     av_frame_get_buffer(enc->frame, 0);
 

--- a/libcastor/src/Muxer.c
+++ b/libcastor/src/Muxer.c
@@ -26,7 +26,13 @@ CASTOR_CORE_API int muxer_add_video_stream(CastorMuxer* mux, AVCodecContext* vct
         return -1;
     }
 
-    mux->video_stream->time_base     = vctx->time_base;
+    /* vctx->time_base peut avoir ete modifie par certains encodeurs
+     * (libvpx-vp9) apres avcodec_open2. On derive la stream time_base depuis
+     * vctx->framerate = {fps, 1} qui, lui, n'est pas touche par libvpx.
+     * av_inv_q({fps, 1}) = {1, fps} — unite "un tick par frame". */
+    mux->video_stream->time_base = (vctx->framerate.num > 0 && vctx->framerate.den > 0)
+        ? av_inv_q(vctx->framerate)
+        : vctx->time_base;
     mux->video_stream->avg_frame_rate = vctx->framerate;
     return 0;
 }

--- a/libcastor/src/Muxer.c
+++ b/libcastor/src/Muxer.c
@@ -26,7 +26,8 @@ CASTOR_CORE_API int muxer_add_video_stream(CastorMuxer* mux, AVCodecContext* vct
         return -1;
     }
 
-    mux->video_stream->time_base = vctx->time_base;
+    mux->video_stream->time_base     = vctx->time_base;
+    mux->video_stream->avg_frame_rate = vctx->framerate;
     return 0;
 }
 

--- a/libcastor/src/Recorder.c
+++ b/libcastor/src/Recorder.c
@@ -202,10 +202,22 @@ static unsigned __stdcall thread_stream_audio(void* arg) {
  *  Init / cleanup d'un stream
  * ================================================================== */
 
+/* Codes de retour de stream_init (et recorder_start) :
+ *  -10 : video_capture_init_source a echoue
+ *  -11 : dimensions video nulles apres capture init
+ *  -12 : audio_capture_init_source a echoue
+ *  -20 : codec video introuvable (libvpx-vp9 / libx264 absent)
+ *  -21 : avcodec_open2 video echoue
+ *  -22 : sws_getContext echoue
+ *  -25 : codec audio introuvable (libopus / AAC absent)
+ *  -26 : avcodec_open2 audio echoue
+ *  -27 : av_audio_fifo_alloc echoue
+ *  -30 : creation de l'output echouee (chemin invalide, RTMP inaccessible)
+ *  -31 : output_add_*_stream ou output_write_header echoue */
 static int stream_init(StreamState* s) {
     if (video_capture_init_source(&s->vctx, &s->config.video_src) < 0) {
         fprintf(stderr, "[Stream %d] Init capture video echouee\n", s->index);
-        return -1;
+        return -10;
     }
 
     /* Sanity check : un codec comme x264 crashe si on l'ouvre avec des dimensions nulles */
@@ -213,7 +225,7 @@ static int stream_init(StreamState* s) {
         fprintf(stderr, "[Stream %d] Dimensions invalides apres init capture: %dx%d\n",
                 s->index, s->vctx.width, s->vctx.height);
         video_capture_cleanup(&s->vctx);
-        return -1;
+        return -11;
     }
     fprintf(stderr, "[Stream %d] Capture video OK — %dx%d (type=%d)\n",
             s->index, s->vctx.width, s->vctx.height, s->config.video_src.type);
@@ -221,7 +233,7 @@ static int stream_init(StreamState* s) {
     if (audio_capture_init_source(&s->actx, &s->config.audio_src) < 0) {
         fprintf(stderr, "[Stream %d] Init capture audio echouee\n", s->index);
         video_capture_cleanup(&s->vctx);
-        return -1;
+        return -12;
     }
     if (s->actx.channels > 2) s->actx.channels = 2;
 
@@ -253,21 +265,23 @@ static int stream_init(StreamState* s) {
         acfg.audio_codec        = s->config.output.audio_codec;
     }
 
-    if (video_encoder_init_ex(&s->venc,
-                              s->vctx.width, s->vctx.height,
-                              s->recorder->config.fps, &vcfg) < 0) {
-        fprintf(stderr, "[Stream %d] Init encodeur video echoue\n", s->index);
+    int enc_ret = video_encoder_init_ex(&s->venc,
+                                        s->vctx.width, s->vctx.height,
+                                        s->recorder->config.fps, &vcfg);
+    if (enc_ret < 0) {
+        fprintf(stderr, "[Stream %d] Init encodeur video echoue (code %d)\n", s->index, enc_ret);
         video_capture_cleanup(&s->vctx);
         audio_capture_cleanup(&s->actx);
-        return -1;
+        return enc_ret; /* -20 / -21 / -22 */
     }
 
-    if (audio_encoder_init_ex(&s->aenc, s->actx.sample_rate, &acfg) < 0) {
-        fprintf(stderr, "[Stream %d] Init encodeur audio echoue\n", s->index);
+    int aenc_ret = audio_encoder_init_ex(&s->aenc, s->actx.sample_rate, &acfg);
+    if (aenc_ret < 0) {
+        fprintf(stderr, "[Stream %d] Init encodeur audio echoue (code %d)\n", s->index, aenc_ret);
         video_encoder_cleanup(&s->venc, NULL);
         video_capture_cleanup(&s->vctx);
         audio_capture_cleanup(&s->actx);
-        return -1;
+        return aenc_ret; /* -25 / -26 / -27 */
     }
 
     /* Creer l'output (fichier ou RTMP) */
@@ -278,7 +292,7 @@ static int stream_init(StreamState* s) {
         audio_encoder_cleanup(&s->aenc, NULL);
         video_capture_cleanup(&s->vctx);
         audio_capture_cleanup(&s->actx);
-        return -1;
+        return -30;
     }
 
     if (output_add_video_stream(s->output, s->venc.ctx) < 0 ||
@@ -291,7 +305,7 @@ static int stream_init(StreamState* s) {
         audio_encoder_cleanup(&s->aenc, NULL);
         video_capture_cleanup(&s->vctx);
         audio_capture_cleanup(&s->actx);
-        return -1;
+        return -31;
     }
 
     InitializeCriticalSection(&s->frame_lock);

--- a/libcastor/src/Recorder.c
+++ b/libcastor/src/Recorder.c
@@ -281,8 +281,29 @@ static int stream_init(StreamState* s) {
         acfg.audio_codec        = s->config.output.audio_codec;
     }
 
+    /* Dimensions de sortie : output_width/height si specifie, sinon capture native. */
+    const int out_w = (s->config.output.output_width  > 0)
+                      ? s->config.output.output_width  : s->vctx.width;
+    const int out_h = (s->config.output.output_height > 0)
+                      ? s->config.output.output_height : s->vctx.height;
+
+    /* Dimensions source pour sws (redimensionnement capture → sortie). */
+    vcfg.src_width  = s->vctx.width;
+    vcfg.src_height = s->vctx.height;
+
+    /* CRF selon le quality_index : 0=haute 1=bonne 2=basse.
+     * Valeurs per-codec : H264 {18,23,28} / VP9 {25,33,40}. */
+    if (!vcfg.cbr) {
+        static const int h264_crf[3] = {18, 23, 28};
+        static const int vp9_crf [3] = {25, 33, 40};
+        int qi = s->config.output.quality_index;
+        if (qi < 0 || qi > 2) qi = 1;
+        vcfg.crf = (vcfg.video_codec == CASTOR_VCODEC_VP9)
+                   ? vp9_crf[qi] : h264_crf[qi];
+    }
+
     int enc_ret = video_encoder_init_ex(&s->venc,
-                                        s->vctx.width, s->vctx.height,
+                                        out_w, out_h,
                                         s->recorder->config.fps, &vcfg);
     if (enc_ret < 0) {
         fprintf(stderr, "[Stream %d] Init encodeur video echoue (code %d)\n", s->index, enc_ret);

--- a/libcastor/src/Recorder.c
+++ b/libcastor/src/Recorder.c
@@ -232,10 +232,25 @@ static int stream_init(StreamState* s) {
     if (s->config.output.type == CASTOR_OUTPUT_RTMP) {
         vcfg = video_encoder_config_rtmp(s->config.output.video_bitrate_kbps,
                                          s->config.output.gop_seconds);
-        acfg.audio_bitrate_kbps = s->config.output.audio_bitrate_kbps;
+        vcfg.video_codec        = CASTOR_VCODEC_H264; /* RTMP = H264 uniquement */
+        acfg.audio_bitrate_kbps = s->config.output.audio_bitrate_kbps > 0
+                                  ? s->config.output.audio_bitrate_kbps : 128;
+        acfg.audio_codec        = CASTOR_ACODEC_AAC;  /* RTMP = AAC uniquement  */
     } else {
-        vcfg = video_encoder_config_default();
-        acfg = audio_encoder_config_default();
+        /* Fichier : CBR si bitrate specifie, CRF sinon */
+        if (s->config.output.video_bitrate_kbps > 0) {
+            vcfg.cbr                = 1;
+            vcfg.video_bitrate_kbps = s->config.output.video_bitrate_kbps;
+            vcfg.gop_seconds        = s->config.output.gop_seconds > 0
+                                      ? s->config.output.gop_seconds : 2;
+            vcfg.zerolatency        = 0;
+        } else {
+            vcfg = video_encoder_config_default();
+        }
+        vcfg.video_codec        = s->config.output.video_codec;
+        acfg.audio_bitrate_kbps = s->config.output.audio_bitrate_kbps > 0
+                                  ? s->config.output.audio_bitrate_kbps : 128;
+        acfg.audio_codec        = s->config.output.audio_codec;
     }
 
     if (video_encoder_init_ex(&s->venc,

--- a/libcastor/src/Recorder.c
+++ b/libcastor/src/Recorder.c
@@ -267,11 +267,11 @@ static int stream_init(StreamState* s) {
     } else {
         /* Fichier : CBR si bitrate specifie, CRF sinon */
         if (s->config.output.video_bitrate_kbps > 0) {
+            vcfg                    = video_encoder_config_default(); /* zero-init */
             vcfg.cbr                = 1;
             vcfg.video_bitrate_kbps = s->config.output.video_bitrate_kbps;
             vcfg.gop_seconds        = s->config.output.gop_seconds > 0
                                       ? s->config.output.gop_seconds : 2;
-            vcfg.zerolatency        = 0;
         } else {
             vcfg = video_encoder_config_default();
         }

--- a/libcastor/src/Recorder.c
+++ b/libcastor/src/Recorder.c
@@ -125,6 +125,12 @@ static unsigned __stdcall thread_stream_video_encode(void* arg) {
         LeaveCriticalSection(&s->frame_lock);
 
         if (vframe) {
+            /* Estampille l'horloge murale en microsecondes.
+             * video_encoder_encode_frame utilisera cette valeur pour calculer
+             * enc->frame->pts via av_rescale_q, garantissant une vitesse de
+             * lecture 1:1 meme si l'encodeur (libvpx-vp9) est plus lent que
+             * le fps cible (ex : 11fps effectif pour une cible de 60fps). */
+            vframe->pts = (int64_t)(elapsed * 1000000.0);
             video_encoder_encode_frame(&s->venc, vframe, s->output);
             av_frame_free(&vframe);
             frames_encoded++;
@@ -215,6 +221,16 @@ static unsigned __stdcall thread_stream_audio(void* arg) {
  *  -30 : creation de l'output echouee (chemin invalide, RTMP inaccessible)
  *  -31 : output_add_*_stream ou output_write_header echoue */
 static int stream_init(StreamState* s) {
+    /* Redirect stderr vers un fichier pour rendre les logs natifs visibles.
+     * Fichier cree dans le repertoire de travail de l'application. */
+    {
+        static int log_opened = 0;
+        if (!log_opened) {
+            if (freopen("castor_debug.log", "w", stderr))
+                log_opened = 1;
+        }
+    }
+
     if (video_capture_init_source(&s->vctx, &s->config.video_src) < 0) {
         fprintf(stderr, "[Stream %d] Init capture video echouee\n", s->index);
         return -10;

--- a/libcastor/src/VideoCapture.cpp
+++ b/libcastor/src/VideoCapture.cpp
@@ -646,8 +646,8 @@ static AVFrame* next_frame_camera(VideoCaptureContextInternal* internal) {
     const int bytes_per_row = internal->width * 4;
     for (int y = 0; y < internal->height; y++) {
         memcpy(frame->data[0] + y * frame->linesize[0],
-           data + y * bytes_per_row,
-           bytes_per_row);
+               data + y * bytes_per_row,
+               bytes_per_row);
     }
 
     buffer->Unlock();

--- a/libcastor/src/VideoCapture.cpp
+++ b/libcastor/src/VideoCapture.cpp
@@ -523,7 +523,7 @@ CASTOR_CORE_API int video_capture_init_source(VideoCaptureContext* ctx, CaptureS
  * ================================================================== */
 
 static AVFrame* next_frame_wgc(VideoCaptureContextInternal* internal) {
-    if (WaitForSingleObject(internal->frame_event, 33)) {
+    if (WaitForSingleObject(internal->frame_event, 33) != WAIT_OBJECT_0) {
         fprintf(stderr, "[WGC] Timeout\n");
         return nullptr;
     }

--- a/libcastor/src/VideoEncode.c
+++ b/libcastor/src/VideoEncode.c
@@ -14,16 +14,27 @@ CASTOR_CORE_API int video_encoder_init_ex(VideoEncoder* enc, int width, int heig
     VideoEncoderConfig defaults = video_encoder_config_default();
     if (!cfg) cfg = &defaults;
 
-    /* Preferer libx264 : supporte CBR, preset, tune=zerolatency.
-     * h264_mf (Media Foundation) ignore ces options et est deconseille pour RTMP. */
-    const AVCodec* codec = avcodec_find_encoder_by_name("libx264");
-    if (!codec) {
-        fprintf(stderr, "[VideoEncoder] libx264 introuvable, fallback vers codec H264 systeme\n");
-        codec = avcodec_find_encoder(AV_CODEC_ID_H264);
-    }
-    if (!codec) {
-        fprintf(stderr, "[VideoEncoder] aucun codec H264 disponible\n");
-        return -1;
+    const AVCodec* codec = NULL;
+    const int use_vp9 = (cfg->video_codec == CASTOR_VCODEC_VP9);
+
+    if (use_vp9) {
+        codec = avcodec_find_encoder_by_name("libvpx-vp9");
+        if (!codec) {
+            fprintf(stderr, "[VideoEncoder] libvpx-vp9 introuvable\n");
+            return -1;
+        }
+    } else {
+        /* Preferer libx264 : supporte CBR, preset, tune=zerolatency.
+         * h264_mf (Media Foundation) ignore ces options et est deconseille pour RTMP. */
+        codec = avcodec_find_encoder_by_name("libx264");
+        if (!codec) {
+            fprintf(stderr, "[VideoEncoder] libx264 introuvable, fallback vers codec H264 systeme\n");
+            codec = avcodec_find_encoder(AV_CODEC_ID_H264);
+        }
+        if (!codec) {
+            fprintf(stderr, "[VideoEncoder] aucun codec H264 disponible\n");
+            return -1;
+        }
     }
     fprintf(stderr, "[VideoEncoder] codec : %s\n", codec->name);
 
@@ -49,25 +60,47 @@ CASTOR_CORE_API int video_encoder_init_ex(VideoEncoder* enc, int width, int heig
     enc->first_pts     = 0;
     enc->first_pts_set = 0;
 
-    /* --- Preset --- */
-    av_opt_set(enc->ctx->priv_data, "preset",
-               cfg->zerolatency ? "ultrafast" : "veryfast", 0);
+    if (use_vp9) {
+        /* --- libvpx-vp9 --- */
+        if (cfg->cbr && cfg->video_bitrate_kbps > 0) {
+            const int bps = cfg->video_bitrate_kbps * 1000;
+            enc->ctx->bit_rate       = bps;
+            enc->ctx->rc_min_rate    = bps;
+            enc->ctx->rc_max_rate    = bps;
+            enc->ctx->rc_buffer_size = cfg->zerolatency ? bps / 2 : bps * 2;
+            av_opt_set(enc->ctx->priv_data, "deadline",
+                       cfg->zerolatency ? "realtime" : "good", 0);
+            av_opt_set(enc->ctx->priv_data, "cpu-used",
+                       cfg->zerolatency ? "8" : "4", 0);
+        } else {
+            /* CQ (constrained quality) — equivalent CRF pour VP9 */
+            enc->ctx->bit_rate = 0;
+            av_opt_set(enc->ctx->priv_data, "deadline", "good", 0);
+            av_opt_set(enc->ctx->priv_data, "cpu-used", "4", 0);
+            av_opt_set_int(enc->ctx->priv_data, "crf", 33, AV_OPT_SEARCH_CHILDREN);
+        }
+    } else {
+        /* --- libx264 --- */
 
-    /* --- Latence zero (streaming) --- */
-    if (cfg->zerolatency)
-        av_opt_set(enc->ctx->priv_data, "tune", "zerolatency", 0);
+        /* Preset */
+        av_opt_set(enc->ctx->priv_data, "preset",
+                   cfg->zerolatency ? "ultrafast" : "veryfast", 0);
 
-    /* --- Mode CBR ou CRF --- */
-    if (cfg->cbr && cfg->video_bitrate_kbps > 0) {
-        const int bps = cfg->video_bitrate_kbps * 1000;
-        enc->ctx->bit_rate    = bps;
-        enc->ctx->rc_min_rate = bps;
-        enc->ctx->rc_max_rate = bps;
-        /* En mode zerolatency (preview live) : VBV = 0.5 s → réduit le buffer
-         * encoder côté RTMP sans casser le flux (x264 tolère ce VBV serré
-         * avec tune=zerolatency car nal-hrd est désactivé).
-         * En mode normal (broadcast) : VBV = 2 s → headroom réseau standard. */
-        enc->ctx->rc_buffer_size = cfg->zerolatency ? bps / 2 : bps * 2;
+        /* Latence zero (streaming) */
+        if (cfg->zerolatency)
+            av_opt_set(enc->ctx->priv_data, "tune", "zerolatency", 0);
+
+        /* Mode CBR ou CRF */
+        if (cfg->cbr && cfg->video_bitrate_kbps > 0) {
+            const int bps = cfg->video_bitrate_kbps * 1000;
+            enc->ctx->bit_rate       = bps;
+            enc->ctx->rc_min_rate    = bps;
+            enc->ctx->rc_max_rate    = bps;
+            /* En mode zerolatency (preview live) : VBV = 0.5 s → réduit le buffer
+             * encoder côté RTMP sans casser le flux.
+             * En mode normal (broadcast) : VBV = 2 s → headroom réseau standard. */
+            enc->ctx->rc_buffer_size = cfg->zerolatency ? bps / 2 : bps * 2;
+        }
     }
 
     if (avcodec_open2(enc->ctx, codec, NULL) < 0) {

--- a/libcastor/src/VideoEncode.c
+++ b/libcastor/src/VideoEncode.c
@@ -68,6 +68,9 @@ CASTOR_CORE_API int video_encoder_init_ex(VideoEncoder* enc, int width, int heig
             enc->ctx->rc_min_rate    = bps;
             enc->ctx->rc_max_rate    = bps;
             enc->ctx->rc_buffer_size = cfg->zerolatency ? bps / 2 : bps * 2;
+            /* end-usage=cbr est obligatoire : sans lui, libvpx ignore bit_rate
+             * et rc_min/max_rate, ce qui peut faire echouer avcodec_open2. */
+            av_opt_set(enc->ctx->priv_data, "end-usage", "cbr", 0);
             av_opt_set(enc->ctx->priv_data, "deadline",
                        cfg->zerolatency ? "realtime" : "good", 0);
             av_opt_set(enc->ctx->priv_data, "cpu-used",
@@ -75,6 +78,8 @@ CASTOR_CORE_API int video_encoder_init_ex(VideoEncoder* enc, int width, int heig
         } else {
             /* CQ (constrained quality) — equivalent CRF pour VP9 */
             enc->ctx->bit_rate = 0;
+            /* end-usage=q active le mode qualite constante de VP9 */
+            av_opt_set(enc->ctx->priv_data, "end-usage", "q", 0);
             av_opt_set(enc->ctx->priv_data, "deadline", "good", 0);
             av_opt_set(enc->ctx->priv_data, "cpu-used", "4", 0);
             av_opt_set_int(enc->ctx->priv_data, "crf", 33, AV_OPT_SEARCH_CHILDREN);

--- a/libcastor/src/VideoEncode.c
+++ b/libcastor/src/VideoEncode.c
@@ -67,9 +67,6 @@ CASTOR_CORE_API int video_encoder_init_ex(VideoEncoder* enc, int width, int heig
     if (!use_vp9)
         enc->ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
 
-    enc->first_pts     = 0;
-    enc->first_pts_set = 0;
-
     if (use_vp9) {
         /* --- libvpx-vp9 ---
          *
@@ -241,11 +238,6 @@ CASTOR_CORE_API int video_encoder_encode_frame(VideoEncoder* enc, AVFrame* src, 
         0, src->height,
         enc->frame->data, enc->frame->linesize
     );
-
-    if (!enc->first_pts_set) {
-        enc->first_pts     = src->pts;
-        enc->first_pts_set = 1;
-    }
 
     /* src->pts est l'horloge murale en microsecondes depuis le debut de
      * l'enregistrement, definie par thread_stream_video_encode.

--- a/libcastor/src/VideoEncode.c
+++ b/libcastor/src/VideoEncode.c
@@ -17,11 +17,15 @@ CASTOR_CORE_API int video_encoder_init_ex(VideoEncoder* enc, int width, int heig
     const AVCodec* codec = NULL;
     const int use_vp9 = (cfg->video_codec == CASTOR_VCODEC_VP9);
 
+    /* Codes de retour :
+     *  -20 : codec introuvable (libvpx-vp9 / libx264 absent de l'avcodec.dll)
+     *  -21 : avcodec_open2 a echoue (configuration invalide)
+     *  -22 : sws_getContext a echoue */
     if (use_vp9) {
         codec = avcodec_find_encoder_by_name("libvpx-vp9");
         if (!codec) {
-            fprintf(stderr, "[VideoEncoder] libvpx-vp9 introuvable\n");
-            return -1;
+            fprintf(stderr, "[VideoEncoder] libvpx-vp9 introuvable — recompilez FFmpeg avec --enable-libvpx\n");
+            return -20;
         }
     } else {
         /* Preferer libx264 : supporte CBR, preset, tune=zerolatency.
@@ -33,7 +37,7 @@ CASTOR_CORE_API int video_encoder_init_ex(VideoEncoder* enc, int width, int heig
         }
         if (!codec) {
             fprintf(stderr, "[VideoEncoder] aucun codec H264 disponible\n");
-            return -1;
+            return -20;
         }
     }
     fprintf(stderr, "[VideoEncoder] codec : %s\n", codec->name);
@@ -55,13 +59,28 @@ CASTOR_CORE_API int video_encoder_init_ex(VideoEncoder* enc, int width, int heig
     enc->ctx->pix_fmt      = AV_PIX_FMT_YUV420P;
     enc->ctx->gop_size     = gop;
     enc->ctx->max_b_frames = 0;
-    enc->ctx->flags       |= AV_CODEC_FLAG_GLOBAL_HEADER;
+    /* AV_CODEC_FLAG_GLOBAL_HEADER :
+     *   H.264 en a besoin (SPS/PPS dans l'avcC/hvcC de MP4/MKV et dans le
+     *   RTMP AVCDecoderConfigurationRecord).
+     *   VP9 n'en a pas besoin : le bitstream est auto-suffisant, et mettre ce
+     *   flag peut produire un CodecPrivate incompatible avec certains players. */
+    if (!use_vp9)
+        enc->ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
 
     enc->first_pts     = 0;
     enc->first_pts_set = 0;
 
     if (use_vp9) {
-        /* --- libvpx-vp9 --- */
+        /* --- libvpx-vp9 ---
+         *
+         * lag-in-frames=0 : desactive le lookahead interne de VP9.
+         * Sans ca, meme en mode CBR, deadline=good active un lookahead de
+         * plusieurs frames : les paquets video ne sortent qu'au flush final,
+         * et av_interleaved_write_frame ne peut plus entrelacer audio+video
+         * correctement → image figee a la lecture.
+         * 0 = pas de lookahead, sortie paquet-par-paquet comme libx264. */
+        av_opt_set_int(enc->ctx->priv_data, "lag-in-frames", 0, 0);
+
         if (cfg->cbr && cfg->video_bitrate_kbps > 0) {
             const int bps = cfg->video_bitrate_kbps * 1000;
             enc->ctx->bit_rate       = bps;
@@ -69,19 +88,26 @@ CASTOR_CORE_API int video_encoder_init_ex(VideoEncoder* enc, int width, int heig
             enc->ctx->rc_max_rate    = bps;
             enc->ctx->rc_buffer_size = cfg->zerolatency ? bps / 2 : bps * 2;
             /* end-usage=cbr est obligatoire : sans lui, libvpx ignore bit_rate
-             * et rc_min/max_rate, ce qui peut faire echouer avcodec_open2. */
+             * et rc_min/max_rate, ce qui peut faire echouer avcodec_open2.
+             *
+             * deadline=realtime (pas "good") : en mode "good", libvpx peut
+             * prendre >16 ms par frame a 1080p, ce qui depasse le frame_interval
+             * a 60fps. Le buffer de av_interleaved_write_frame sature alors en
+             * ~0,5 s et les paquets VP9 ne sont plus ecrits → image figee.
+             * "realtime" garantit un paquet sorti pour chaque frame envoyee,
+             * quel que soit le debit CPU disponible.
+             * cpu-used : 8=preview ultra-rapide, 6=enregistrement fichier. */
             av_opt_set(enc->ctx->priv_data, "end-usage", "cbr", 0);
-            av_opt_set(enc->ctx->priv_data, "deadline",
-                       cfg->zerolatency ? "realtime" : "good", 0);
+            av_opt_set(enc->ctx->priv_data, "deadline", "realtime", 0);
             av_opt_set(enc->ctx->priv_data, "cpu-used",
-                       cfg->zerolatency ? "8" : "4", 0);
+                       cfg->zerolatency ? "8" : "6", 0);
         } else {
-            /* CQ (constrained quality) — equivalent CRF pour VP9 */
+            /* CQ (constrained quality) — equivalent CRF pour VP9.
+             * Meme contrainte temps-reel : deadline=realtime + cpu-used=6. */
             enc->ctx->bit_rate = 0;
-            /* end-usage=q active le mode qualite constante de VP9 */
             av_opt_set(enc->ctx->priv_data, "end-usage", "q", 0);
-            av_opt_set(enc->ctx->priv_data, "deadline", "good", 0);
-            av_opt_set(enc->ctx->priv_data, "cpu-used", "4", 0);
+            av_opt_set(enc->ctx->priv_data, "deadline", "realtime", 0);
+            av_opt_set(enc->ctx->priv_data, "cpu-used", "6", 0);
             av_opt_set_int(enc->ctx->priv_data, "crf", 33, AV_OPT_SEARCH_CHILDREN);
         }
     } else {
@@ -111,8 +137,25 @@ CASTOR_CORE_API int video_encoder_init_ex(VideoEncoder* enc, int width, int heig
     if (avcodec_open2(enc->ctx, codec, NULL) < 0) {
         fprintf(stderr, "[VideoEncoder] avcodec_open2 failed\n");
         avcodec_free_context(&enc->ctx);
-        return -1;
+        return -21;
     }
+
+    /* Certains encodeurs (libvpx-vp9) modifient ctx->time_base apres open.
+     * On sauvegarde le fps cible pour calculer correctement les pts via
+     * av_rescale_q dans video_encoder_encode_frame. */
+    enc->fps = fps;
+    fprintf(stderr, "[VideoEncoder] time_base apres open : %d/%d (fps cible : %d)\n",
+            enc->ctx->time_base.num, enc->ctx->time_base.den, fps);
+
+    /* Force time_base et framerate apres open : libvpx-vp9 peut les modifier.
+     * Avec lag-in-frames=0, VP9 repasse les pts 1:1 (input→output),
+     * donc forcer ces valeurs est sans risque et garantit la coherence
+     * avec muxer_add_video_stream et av_packet_rescale_ts. */
+    enc->ctx->time_base = (AVRational){ 1, fps };
+    enc->ctx->framerate = (AVRational){ fps, 1 };
+    fprintf(stderr, "[VideoEncoder] time_base FORCE: %d/%d  framerate FORCE: %d/%d\n",
+            enc->ctx->time_base.num, enc->ctx->time_base.den,
+            enc->ctx->framerate.num, enc->ctx->framerate.den);
 
     enc->frame = av_frame_alloc();
     enc->frame->format = AV_PIX_FMT_YUV420P;
@@ -129,7 +172,7 @@ CASTOR_CORE_API int video_encoder_init_ex(VideoEncoder* enc, int width, int heig
         fprintf(stderr, "[VideoEncoder] sws_getContext failed\n");
         avcodec_free_context(&enc->ctx);
         av_frame_free(&enc->frame);
-        return -1;
+        return -22;
     }
 
     enc->pkt         = av_packet_alloc();
@@ -190,7 +233,24 @@ CASTOR_CORE_API int video_encoder_encode_frame(VideoEncoder* enc, AVFrame* src, 
         enc->first_pts_set = 1;
     }
 
-    enc->frame->pts = enc->frame_index++;
+    /* av_rescale_q convertit le numero de frame (en unite {1, fps}) vers
+     * l'unite reelle de ctx->time_base, qui peut avoir ete modifiee par le
+     * codec (libvpx-vp9 peut changer time_base apres avcodec_open2).
+     * Sans cette conversion, frame->pts serait interprete dans la mauvaise
+     * unite et la video jouerait en accelere ou au ralenti. */
+    enc->frame->pts = av_rescale_q(enc->frame_index,
+                                   (AVRational){ 1, enc->fps },
+                                   enc->ctx->time_base);
+
+    if (enc->frame_index < 5)
+        fprintf(stderr, "[VideoEnc DBG] frame=%d  ctx_tb=%d/%d  fps=%d  frame_pts=%lld"
+                        "  stream_vtb=%d/%d\n",
+                enc->frame_index,
+                enc->ctx->time_base.num, enc->ctx->time_base.den,
+                enc->fps, (long long)enc->frame->pts,
+                out->video_stream_time_base.num, out->video_stream_time_base.den);
+
+    enc->frame_index++;
 
     int ret = avcodec_send_frame(enc->ctx, enc->frame);
     if (ret < 0) {
@@ -202,8 +262,23 @@ CASTOR_CORE_API int video_encoder_encode_frame(VideoEncoder* enc, AVFrame* src, 
 
     while (avcodec_receive_packet(enc->ctx, enc->pkt) == 0) {
         enc->pkt->stream_index = out->video_stream_index;
+
+        if (enc->frame_index <= 5) {
+            fprintf(stderr, "[VideoEnc DBG] pkt PRE-rescale : pts=%lld dts=%lld"
+                            "  src_tb=%d/%d  dst_tb=%d/%d\n",
+                    (long long)enc->pkt->pts, (long long)enc->pkt->dts,
+                    enc->ctx->time_base.num, enc->ctx->time_base.den,
+                    out->video_stream_time_base.num, out->video_stream_time_base.den);
+        }
+
         av_packet_rescale_ts(enc->pkt, enc->ctx->time_base,
                              out->video_stream_time_base);
+
+        if (enc->frame_index <= 5) {
+            fprintf(stderr, "[VideoEnc DBG] pkt POST-rescale: pts=%lld dts=%lld\n",
+                    (long long)enc->pkt->pts, (long long)enc->pkt->dts);
+        }
+
         output_write_packet(out, enc->pkt);
         av_packet_unref(enc->pkt);
     }

--- a/libcastor/src/VideoEncode.c
+++ b/libcastor/src/VideoEncode.c
@@ -274,23 +274,8 @@ CASTOR_CORE_API int video_encoder_encode_frame(VideoEncoder* enc, AVFrame* src, 
 
     while (avcodec_receive_packet(enc->ctx, enc->pkt) == 0) {
         enc->pkt->stream_index = out->video_stream_index;
-
-        if (enc->frame_index <= 5) {
-            fprintf(stderr, "[VideoEnc DBG] pkt PRE-rescale : pts=%lld dts=%lld"
-                            "  src_tb=%d/%d  dst_tb=%d/%d\n",
-                    (long long)enc->pkt->pts, (long long)enc->pkt->dts,
-                    enc->ctx->time_base.num, enc->ctx->time_base.den,
-                    out->video_stream_time_base.num, out->video_stream_time_base.den);
-        }
-
         av_packet_rescale_ts(enc->pkt, enc->ctx->time_base,
                              out->video_stream_time_base);
-
-        if (enc->frame_index <= 5) {
-            fprintf(stderr, "[VideoEnc DBG] pkt POST-rescale: pts=%lld dts=%lld\n",
-                    (long long)enc->pkt->pts, (long long)enc->pkt->dts);
-        }
-
         output_write_packet(out, enc->pkt);
         av_packet_unref(enc->pkt);
     }

--- a/libcastor/src/VideoEncode.c
+++ b/libcastor/src/VideoEncode.c
@@ -107,7 +107,10 @@ CASTOR_CORE_API int video_encoder_init_ex(VideoEncoder* enc, int width, int heig
             enc->ctx->bit_rate = 0;
             av_opt_set(enc->ctx->priv_data, "end-usage", "q", 0);
             av_opt_set(enc->ctx->priv_data, "deadline", "realtime", 0);
-            av_opt_set(enc->ctx->priv_data, "cpu-used", "6", 0);
+            /* cpu-used=8 : encodage le plus rapide (qualite legèrement reduite).
+             * VP9 en mode fichier peut etre lent a haute resolution ; 8 permet
+             * d'approcher le fps cible sans ralentir le thread d'encodage. */
+            av_opt_set(enc->ctx->priv_data, "cpu-used", "8", 0);
             av_opt_set_int(enc->ctx->priv_data, "crf", 33, AV_OPT_SEARCH_CHILDREN);
         }
     } else {
@@ -233,22 +236,20 @@ CASTOR_CORE_API int video_encoder_encode_frame(VideoEncoder* enc, AVFrame* src, 
         enc->first_pts_set = 1;
     }
 
-    /* av_rescale_q convertit le numero de frame (en unite {1, fps}) vers
-     * l'unite reelle de ctx->time_base, qui peut avoir ete modifiee par le
-     * codec (libvpx-vp9 peut changer time_base apres avcodec_open2).
-     * Sans cette conversion, frame->pts serait interprete dans la mauvaise
-     * unite et la video jouerait en accelere ou au ralenti. */
-    enc->frame->pts = av_rescale_q(enc->frame_index,
-                                   (AVRational){ 1, enc->fps },
-                                   enc->ctx->time_base);
-
-    if (enc->frame_index < 5)
-        fprintf(stderr, "[VideoEnc DBG] frame=%d  ctx_tb=%d/%d  fps=%d  frame_pts=%lld"
-                        "  stream_vtb=%d/%d\n",
-                enc->frame_index,
-                enc->ctx->time_base.num, enc->ctx->time_base.den,
-                enc->fps, (long long)enc->frame->pts,
-                out->video_stream_time_base.num, out->video_stream_time_base.den);
+    /* src->pts est l'horloge murale en microsecondes depuis le debut de
+     * l'enregistrement, definie par thread_stream_video_encode.
+     * Cela garantit une vitesse de lecture 1:1 meme si l'encodeur est plus
+     * lent que le fps cible (ex : VP9 a 11fps effectif sur une cible de 60fps).
+     * Fallback sur frame_index si src->pts n'est pas disponible. */
+    if (src->pts != AV_NOPTS_VALUE && src->pts >= 0) {
+        enc->frame->pts = av_rescale_q(src->pts,
+                                       (AVRational){ 1, 1000000 },
+                                       enc->ctx->time_base);
+    } else {
+        enc->frame->pts = av_rescale_q(enc->frame_index,
+                                       (AVRational){ 1, enc->fps },
+                                       enc->ctx->time_base);
+    }
 
     enc->frame_index++;
 

--- a/libcastor/src/VideoEncode.c
+++ b/libcastor/src/VideoEncode.c
@@ -103,7 +103,7 @@ CASTOR_CORE_API int video_encoder_init_ex(VideoEncoder* enc, int width, int heig
                        cfg->zerolatency ? "8" : "6", 0);
         } else {
             /* CQ (constrained quality) — equivalent CRF pour VP9.
-             * Meme contrainte temps-reel : deadline=realtime + cpu-used=6. */
+             * Meme contrainte temps-reel : deadline=realtime + cpu-used=8. */
             enc->ctx->bit_rate = 0;
             av_opt_set(enc->ctx->priv_data, "end-usage", "q", 0);
             av_opt_set(enc->ctx->priv_data, "deadline", "realtime", 0);
@@ -111,7 +111,9 @@ CASTOR_CORE_API int video_encoder_init_ex(VideoEncoder* enc, int width, int heig
              * VP9 en mode fichier peut etre lent a haute resolution ; 8 permet
              * d'approcher le fps cible sans ralentir le thread d'encodage. */
             av_opt_set(enc->ctx->priv_data, "cpu-used", "8", 0);
-            av_opt_set_int(enc->ctx->priv_data, "crf", 33, AV_OPT_SEARCH_CHILDREN);
+            av_opt_set_int(enc->ctx->priv_data, "crf",
+                           cfg->crf > 0 ? cfg->crf : 33,
+                           AV_OPT_SEARCH_CHILDREN);
         }
     } else {
         /* --- libx264 --- */
@@ -134,6 +136,9 @@ CASTOR_CORE_API int video_encoder_init_ex(VideoEncoder* enc, int width, int heig
              * encoder côté RTMP sans casser le flux.
              * En mode normal (broadcast) : VBV = 2 s → headroom réseau standard. */
             enc->ctx->rc_buffer_size = cfg->zerolatency ? bps / 2 : bps * 2;
+        } else if (cfg->crf > 0) {
+            /* CRF explicite fourni par l'utilisateur (qualite configurable). */
+            av_opt_set_int(enc->ctx->priv_data, "crf", cfg->crf, AV_OPT_SEARCH_CHILDREN);
         }
     }
 
@@ -166,9 +171,15 @@ CASTOR_CORE_API int video_encoder_init_ex(VideoEncoder* enc, int width, int heig
     enc->frame->height = height;
     av_frame_get_buffer(enc->frame, 32);
 
+    /* src_width/src_height : dimensions de la frame capturee (entree sws).
+     * width/height          : dimensions de sortie (encodeur + frame allouee).
+     * Si src non specifie, on suppose capture = sortie (pas de redimensionnement). */
+    const int sws_src_w = (cfg->src_width  > 0) ? cfg->src_width  : width;
+    const int sws_src_h = (cfg->src_height > 0) ? cfg->src_height : height;
+
     enc->sws_ctx = sws_getContext(
-        width, height, AV_PIX_FMT_BGRA,
-        width, height, AV_PIX_FMT_YUV420P,
+        sws_src_w, sws_src_h, AV_PIX_FMT_BGRA,
+        width,     height,    AV_PIX_FMT_YUV420P,
         SWS_BILINEAR, NULL, NULL, NULL
     );
     if (!enc->sws_ctx) {

--- a/libcastor/src/output/file_output.c
+++ b/libcastor/src/output/file_output.c
@@ -38,11 +38,21 @@ static int file_add_audio_stream(CastorOutput* self, AVCodecContext* actx)
 static int file_write_header(CastorOutput* self)
 {
     CastorFileOutput* fo = (CastorFileOutput*)self;
+
+    fprintf(stderr, "[FileOutput] stream tb AVANT write_header : video=%d/%d audio=%d/%d\n",
+            fo->mux.video_stream->time_base.num, fo->mux.video_stream->time_base.den,
+            fo->mux.audio_stream->time_base.num, fo->mux.audio_stream->time_base.den);
+
     if (muxer_write_header(&fo->mux) < 0) return -1;
 
     /* Relire les time_base apres write_header (le muxer peut les modifier). */
     self->video_stream_time_base = fo->mux.video_stream->time_base;
     self->audio_stream_time_base = fo->mux.audio_stream->time_base;
+
+    fprintf(stderr, "[FileOutput] stream tb APRES write_header : video=%d/%d audio=%d/%d\n",
+            self->video_stream_time_base.num, self->video_stream_time_base.den,
+            self->audio_stream_time_base.num, self->audio_stream_time_base.den);
+
     return 0;
 }
 

--- a/libcastor/vcpkg.json
+++ b/libcastor/vcpkg.json
@@ -1,9 +1,23 @@
 {
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "castor-studio",
+  "version": "0.1.0",
   "dependencies": [
-    "pthreads",
     {
       "name": "ffmpeg",
-      "features": [ "x264" ]
-    }
+      "features": [
+        "avcodec",
+        "avdevice",
+        "avfilter",
+        "avformat",
+        "swresample",
+        "swscale",
+        "gpl",
+        "x264",
+        "vpx",
+        "opus"
+      ]
+    },
+    "pthreads"
   ]
 }


### PR DESCRIPTION
## Summary

- **Débit enregistrement/stream séparés** : le slider "Débit enregistrement" dans Vidéo contrôle uniquement le fichier ; un nouveau slider "Débit stream" est ajouté dans Streaming (défaut 4000 kbps).
- **Résolution de sortie fonctionnelle** : le ComboBox 1080p / 720p / 480p est maintenant branché — `sws_scale` redimensionne la capture vers la résolution choisie à l'encodage.
- **Qualité CRF configurable** : nouveau ComboBox Haute / Bonne / Basse pour les enregistrements sans débit fixe (H264 : 18/23/28, VP9 : 25/33/40).

## Détails techniques

### Encodage vidéo (`libcastor`)
- `VideoEncoderConfig` : ajout de `src_width/src_height` (dimensions capture → sws) et `crf` (valeur explicite).
- `OutputConfig` : ajout de `output_width/height` et `quality_index`.
- `video_encoder_config_default()` et `video_encoder_config_rtmp()` passent à `= {0}` pour zero-initialiser les nouveaux champs — évite des variables non initialisées.
- `Recorder.c` : calcule les dimensions de sortie, passe les dims source à sws, traduit `quality_index` en CRF per-codec.
- Suppression des champs morts `first_pts` / `first_pts_set` dans `VideoEncoder` (plus utilisés depuis le fix des timestamps par horloge murale).
- Correction d'indentation dans `next_frame_camera` (`memcpy` args alignés).

### UI / Settings (`CastorApplication`)
- `ApplicationSettings` : `StreamingBitrate` (4000 kbps) et `RecordingQualityIndex` (1 = Bonne).
- `StreamingSettingsViewModel` + `StreamingSettingsView` : slider débit stream 500–10 000 kbps.
- `VideoSettingsViewModel` + `VideoSettingsView` : `SelectedQualityIndex` + ComboBox qualité ; label "Débit enregistrement" clarifié.
- `StudioViewModel` : `OutputResolutionFromIndex()` + transmission résolution/qualité à `RecorderService.Start()`.
- `CastorNative.cs` : `OutputConfig` mis à jour avec `OutputWidth`, `OutputHeight`, `QualityIndex`.

## Test plan
- [ ] Enregistrement MKV : vérifier que la vidéo joue à la bonne vitesse et résolution
- [ ] Enregistrement WebM : vérifier synchro audio/vidéo et vitesse 1:1
- [ ] Changer la résolution de sortie (1080p → 720p) et vérifier le fichier produit
- [ ] Changer la qualité (Haute / Basse) et comparer la taille des fichiers
- [ ] Démarrer un stream : vérifier que le débit stream est bien celui du slider Streaming
- [ ] Vérifier que le slider "Débit enregistrement" n'affecte pas le stream